### PR TITLE
Fix characteristic filtering

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -209,7 +209,7 @@ NobleBindings.prototype.discoverCharacteristics =
 			checkCommunicationResult(deviceUuid, result);
 
 			let characteristics = rt.toArray(result.characteristics)
-				.filter(filterUuids(filterCharacteristicUuids))
+				.filter(c => { return filterUuids(filterCharacteristicUuids)(formatUuid(c.uuid)); })
 				.map(c => ({
 					uuid: formatUuid(c.uuid),
 					properties: characteristicPropertiesToStrings(c.characteristicProperties),


### PR DESCRIPTION
Characteristic objects were being sent to filterUuid, instead of their normalized UUID. This patch fixes that so that characteristic filtering works again.

Fixes #5