### PR TITLE
fix for missing connection change event

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -634,6 +634,12 @@ NobleBindings.prototype._onAdvertisementWatcherStopped = function(sender, e) {
 
 NobleBindings.prototype._onConnectionStatusChanged = function(sender, e) {
 	const deviceUuid = sender.bluetoothAddress.toString(16);
+	// we store the uuid in strings of length 12
+	// make sure we get the correct length by appending 000...
+	let deviceUuid = sender.bluetoothAddress.toString(16);
+	if (deviceUuid.length < 12) {
+		deviceUuid = Array(12 - deviceUuid.length + 1).join('0') + deviceUuid;
+	}
 	const deviceRecord = this._deviceMap[deviceUuid];
 	if (deviceRecord) {
 		const connectionStatus = sender.connectionStatus;


### PR DESCRIPTION
Hi realized that i had no disconnect events on windows. After debugging it i realized that my device was stored as ```00000190a0c2``` in ```_deviceMap``` but doing ``` sender.bluetoothAddress.toString(16)``` in ```_onConnectionStatusChanged``` was only returning ```190a0c2``` 
This PR fixes this by appending zeros