### PR TITLE
Set characteristic reads to be uncached by default

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -261,7 +261,7 @@ NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicU
 
 	this._getCachedCharacteristicAsync(
 			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
-		return rt.promisify(characteristic.readValueAsync, characteristic)().then(result => {
+		return rt.promisify(characteristic.readValueAsync, characteristic)(BluetoothCacheMode.uncached).then(result => {
 			checkCommunicationResult(deviceUuid, result);
 			let data = rt.toBuffer(result.value);
 


### PR DESCRIPTION
Resolves #48 
Cached reads may be desirable in some situations but I was unable to find a way to force a cache update.  This is an issue while polling sensors.