### PR TITLE
Extending UWP specific methods. Format unification

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,25 @@
 
 const os = require('os');
 
+// noble-uwp acts as a shim to noble. If Windows >= 10.0.15014, it will bind UWP to noble interface
+// Otherwise, it will either fail (on Windows), or revert back to noble (noble does not have default-Windows support)
 if (os.platform() === 'win32') {
 	const ver = os.release().split('.').map(Number);
 	if (!(ver[0] > 10 ||
-			(ver[0] === 10 && ver[1] > 0) ||
-			(ver[0] === 10 && ver[1] === 0 && ver[2] >= 15014))) {
+		(ver[0] === 10 && ver[1] > 0) ||
+		(ver[0] === 10 && ver[1] === 0 && ver[2] >= 15014))) {
 		throw new Error("Noble UWP bindings require Windows >= 10.0.15014.");
 	}
 
 	const Noble = require('noble/lib/noble');
 	const uwpBindings = require('./lib/bindings.js');
-	module.exports = new Noble(uwpBindings);
+	const uwpAddition = require('./lib/uwpAddition.js');
+
+	var nobleInstance = new Noble(uwpBindings);
+	uwpAddition.init(nobleInstance._bindings);
+	nobleInstance.uwp = uwpAddition;
+
+	module.exports = nobleInstance;
 } else {
-	module.exports = require('noble');;
+	module.exports = require('noble');
 }

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -474,7 +474,7 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 
 	let serviceUuids = undefined;
 	const isScanResponse = e.advertisementType === BluetoothLEAdvertisementType.scanResponse;
-	if (this._acceptOnlyScanResponse && isScanResponse) {
+	if (isScanResponse) {
 		if (!this._deviceMap[deviceUuid]) {
 			debug('	Ignoring scan response for unknown device');
 			return;
@@ -601,7 +601,7 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 		deviceRecord.txPowerLevel = txPowerLevel;
 	}
 
-	// Wait until the response to the active query before emitting a 'discover' event.
+	// If only responding to scan responses, wait until the response to the active query before emitting a 'discover' event.
 	if (!this._acceptOnlyScanResponse || isScanResponse) {
 		let advertisement = {
 			localName: deviceRecord.name,

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -25,13 +25,15 @@ const BluetoothLEAdvertisementWatcher = Windows.Devices.Bluetooth.Advertisement.
 const BluetoothLEScanningMode = Windows.Devices.Bluetooth.Advertisement.BluetoothLEScanningMode;
 const BluetoothLEAdvertisementType = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementType;
 const BluetoothLEAdvertisementDataTypes = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataTypes;
-const BluetoothLEAdvertisementWatcherStatus = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus;
+const BluetoothLEAdvertisementWatcherStatus =
+		Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus;
 
 const GattCharacteristicProperties = Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicProperties;
 const GattDeviceService = Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceService;
 const GattServiceUuids = Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceUuids;
 const GattCommunicationStatus = Windows.Devices.Bluetooth.GenericAttributeProfile.GattCommunicationStatus;
-const GattClientCharacteristicConfigurationDescriptorValue = Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientCharacteristicConfigurationDescriptorValue;
+const GattClientCharacteristicConfigurationDescriptorValue =
+		Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientCharacteristicConfigurationDescriptorValue;
 
 const Radio = Windows.Devices.Radios.Radio;
 const RadioKind = Windows.Devices.Radios.RadioKind;
@@ -44,7 +46,7 @@ let NobleBindings = function () {
 	this._radioState = 'unknown';
 	this._deviceMap = {};
 	this._listenerMap = {};
-	this._acceptOnlyScanResponse = true;
+	this._acceptOnlyScanResponse = false;
 };
 
 util.inherits(NobleBindings, events.EventEmitter);

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -25,15 +25,13 @@ const BluetoothLEAdvertisementWatcher = Windows.Devices.Bluetooth.Advertisement.
 const BluetoothLEScanningMode = Windows.Devices.Bluetooth.Advertisement.BluetoothLEScanningMode;
 const BluetoothLEAdvertisementType = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementType;
 const BluetoothLEAdvertisementDataTypes = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataTypes;
-const BluetoothLEAdvertisementWatcherStatus =
-	Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus;
+const BluetoothLEAdvertisementWatcherStatus = Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus;
 
 const GattCharacteristicProperties = Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicProperties;
 const GattDeviceService = Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceService;
 const GattServiceUuids = Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceUuids;
 const GattCommunicationStatus = Windows.Devices.Bluetooth.GenericAttributeProfile.GattCommunicationStatus;
-const GattClientCharacteristicConfigurationDescriptorValue =
-	Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientCharacteristicConfigurationDescriptorValue;
+const GattClientCharacteristicConfigurationDescriptorValue = Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientCharacteristicConfigurationDescriptorValue;
 
 const Radio = Windows.Devices.Radios.Radio;
 const RadioKind = Windows.Devices.Radios.RadioKind;
@@ -41,16 +39,17 @@ const RadioState = Windows.Devices.Radios.RadioState;
 
 const DataReader = Windows.Storage.Streams.DataReader;
 
-let NobleBindings = function() {
+let NobleBindings = function () {
 	this._radio = null;
 	this._radioState = 'unknown';
 	this._deviceMap = {};
 	this._listenerMap = {};
+	this._acceptOnlyScanResponse = true;
 };
 
 util.inherits(NobleBindings, events.EventEmitter);
 
-NobleBindings.prototype.init = function() {
+NobleBindings.prototype.init = function () {
 	this._onAdvertisementWatcherReceived = this._onAdvertisementWatcherReceived.bind(this);
 	this._onAdvertisementWatcherStopped = this._onAdvertisementWatcherStopped.bind(this);
 	this._onConnectionStatusChanged = this._onConnectionStatusChanged.bind(this);
@@ -67,6 +66,9 @@ NobleBindings.prototype.init = function() {
 		this._radio = radiosList.find(radio => radio.kind === RadioKind.bluetooth);
 		if (this._radio) {
 			debug('found bluetooth radio: %s', this._radio.name);
+			this._radio.on('stateChanged', (sender, e) => {
+				this._updateRadioState();
+			});
 		} else {
 			debug('no bluetooth radio found');
 		}
@@ -77,7 +79,7 @@ NobleBindings.prototype.init = function() {
 	});
 };
 
-NobleBindings.prototype.startScanning = function(serviceUuids, allowDuplicates) {
+NobleBindings.prototype.startScanning = function (serviceUuids, allowDuplicates) {
 	if (!(serviceUuids && serviceUuids.length > 0)) {
 		serviceUuids = null;
 	}
@@ -96,7 +98,7 @@ NobleBindings.prototype.startScanning = function(serviceUuids, allowDuplicates) 
 	rt.keepAlive(true);
 }
 
-NobleBindings.prototype.stopScanning = function() {
+NobleBindings.prototype.stopScanning = function () {
 	if (this._advertisementWatcher.status === BluetoothLEAdvertisementWatcherStatus.started) {
 		debug('stopScanning()');
 		this._advertisementWatcher.stop();
@@ -104,7 +106,7 @@ NobleBindings.prototype.stopScanning = function() {
 	}
 };
 
-NobleBindings.prototype.connect = function(deviceUuid) {
+NobleBindings.prototype.connect = function (deviceUuid) {
 	debug('connect(%s)', deviceUuid);
 
 	let deviceRecord = this._deviceMap[deviceUuid];
@@ -131,7 +133,7 @@ NobleBindings.prototype.connect = function(deviceUuid) {
 	});
 };
 
-NobleBindings.prototype.disconnect = function(deviceUuid) {
+NobleBindings.prototype.disconnect = function (deviceUuid) {
 	debug('disconnect(%s)', deviceUuid);
 
 	let deviceRecord = this._deviceMap[deviceUuid];
@@ -155,7 +157,7 @@ NobleBindings.prototype.disconnect = function(deviceUuid) {
 	}
 };
 
-NobleBindings.prototype.updateRssi = function(deviceUuid) {
+NobleBindings.prototype.updateRssi = function (deviceUuid) {
 	debug('updateRssi(%s)', deviceUuid);
 
 	// TODO: Retrieve updated RSSI
@@ -164,11 +166,11 @@ NobleBindings.prototype.updateRssi = function(deviceUuid) {
 	this.emit('rssiUpdate', deviceUuid, rssi);
 };
 
-NobleBindings.prototype.discoverServices = function(deviceUuid, filterServiceUuids) {
+NobleBindings.prototype.discoverServices = function (deviceUuid, filterServiceUuids) {
 	if (filterServiceUuids && filterServiceUuids.length === 0) {
 		filterServiceUuids = null;
 	}
-	
+
 	debug('discoverServices(%s, %s)', deviceUuid,
 		(filterServiceUuids ? filterServiceUuids.join() : '(all)'));
 
@@ -183,255 +185,255 @@ NobleBindings.prototype.discoverServices = function(deviceUuid, filterServiceUui
 	}
 
 	rt.promisify(device.getGattServicesAsync, device)(
-			BluetoothCacheMode.uncached).then(result => {
-		checkCommunicationResult(deviceUuid, result);
+		BluetoothCacheMode.uncached).then(result => {
+			checkCommunicationResult(deviceUuid, result);
 
-		let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
-		let serviceUuids = services.map(s => uuidToString(s.uuid))
-			.filter(filterUuids(filterServiceUuids));
+			let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
+			let serviceUuids = services.map(s => uuidToString(s.uuid))
+				.filter(filterUuids(filterServiceUuids));
 
-		debug(deviceUuid + ' services: %o', serviceUuids);
-		this.emit('servicesDiscover', deviceUuid, serviceUuids);
-	}).catch(ex => {
-		debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
-		this.emit('servicesDiscover', deviceUuid, ex);
-	});
+			debug(deviceUuid + ' services: %o', serviceUuids);
+			this.emit('servicesDiscover', deviceUuid, serviceUuids);
+		}).catch(ex => {
+			debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
+			this.emit('servicesDiscover', deviceUuid, ex);
+		});
 };
 
 NobleBindings.prototype.discoverIncludedServices =
-function(deviceUuid, serviceUuid, filterServiceUuids) {
-	if (filterServiceUuids && filterServiceUuids.length === 0) {
-		filterServiceUuids = null;
-	}
-	
-	debug('discoverIncludedServices(%s, %s, %s)', deviceUuid, serviceUuid,
-		(filterServiceUuids ? filterServiceUuids.join() : '(all)'));
+	function (deviceUuid, serviceUuid, filterServiceUuids) {
+		if (filterServiceUuids && filterServiceUuids.length === 0) {
+			filterServiceUuids = null;
+		}
 
-	this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
-		rt.promisify(service.getIncludedServicesAsync, service)(
+		debug('discoverIncludedServices(%s, %s, %s)', deviceUuid, serviceUuid,
+			(filterServiceUuids ? filterServiceUuids.join() : '(all)'));
+
+		this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
+			rt.promisify(service.getIncludedServicesAsync, service)(
 				BluetoothCacheMode.uncached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
+					checkCommunicationResult(deviceUuid, result);
 
-			let includedServices = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
-			let includedServiceUuids = includedServices.map(s => uuidToString(s.uuid))
-				.filter(filterUuids(filterServiceUuids));
+					let includedServices = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
+					let includedServiceUuids = includedServices.map(s => uuidToString(s.uuid))
+						.filter(filterUuids(filterServiceUuids));
 
-			debug(deviceUuid + ' ' + serviceUuid + ' included services: ' + includedServiceUuids);
-			this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+					debug(deviceUuid + ' ' + serviceUuid + ' included services: ' + includedServiceUuids);
+					this.emit('includedServicesDiscover', deviceUuid, serviceUuid, includedServiceUuids);
+				});
+		}).catch(ex => {
+			debug('failed to get GATT included services for device %s: %s', deviceUuid, + ex.stack);
+			this.emit('includedServicesDiscover', deviceUuid, serviceUuid, ex);
 		});
-	}).catch(ex => {
-		debug('failed to get GATT included services for device %s: %s', deviceUuid, + ex.stack);
-		this.emit('includedServicesDiscover', deviceUuid, serviceUuid, ex);
-	});
-};
+	};
 
 NobleBindings.prototype.discoverCharacteristics =
-		function(deviceUuid, serviceUuid, filterCharacteristicUuids) {
-	if (filterCharacteristicUuids && filterCharacteristicUuids.length === 0) {
-		filterCharacteristicUuids = null;
-	}
+	function (deviceUuid, serviceUuid, filterCharacteristicUuids) {
+		if (filterCharacteristicUuids && filterCharacteristicUuids.length === 0) {
+			filterCharacteristicUuids = null;
+		}
 
-	debug('discoverCharacteristics(%s, %s, %s', deviceUuid, serviceUuid,
-		(filterCharacteristicUuids ? filterCharacteristicUuids.join() : '(all)'));
+		debug('discoverCharacteristics(%s, %s, %s', deviceUuid, serviceUuid,
+			(filterCharacteristicUuids ? filterCharacteristicUuids.join() : '(all)'));
 
-	this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
-		return rt.promisify(service.getCharacteristicsAsync, service)(
+		this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
+			return rt.promisify(service.getCharacteristicsAsync, service)(
 				BluetoothCacheMode.uncached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
+					checkCommunicationResult(deviceUuid, result);
 
-			let characteristics = rt.toArray(result.characteristics)
-				.filter(c => { return filterUuids(filterCharacteristicUuids)(uuidToString(c.uuid)); })
-				.map(c => ({
-					uuid: uuidToString(c.uuid),
-					properties: characteristicPropertiesToStrings(c.characteristicProperties),
-				}));
+					let characteristics = rt.toArray(result.characteristics)
+						.filter(c => { return filterUuids(filterCharacteristicUuids)(uuidToString(c.uuid)); })
+						.map(c => ({
+							uuid: uuidToString(c.uuid),
+							properties: characteristicPropertiesToStrings(c.characteristicProperties),
+						}));
 
-			debug('%s %s characteristics: %o', deviceUuid, serviceUuid,
-				characteristics.map(c => c.uuid));
-			this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+					debug('%s %s characteristics: %o', deviceUuid, serviceUuid,
+						characteristics.map(c => c.uuid));
+					this.emit('characteristicsDiscover', deviceUuid, serviceUuid, characteristics);
+				});
+		}).catch(ex => {
+			debug('failed to get GATT characteristics for device %s: %s', deviceUuid, ex.stack);
+			this.emit('characteristicsDiscover', deviceUuid, serviceUuid, ex);
 		});
-	}).catch(ex => {
-		debug('failed to get GATT characteristics for device %s: %s', deviceUuid, ex.stack);
-		this.emit('characteristicsDiscover', deviceUuid, serviceUuid, ex);
-	});
-};
+	};
 
-NobleBindings.prototype.read = function(deviceUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.read = function (deviceUuid, serviceUuid, characteristicUuid) {
 	debug('read(%s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid);
 
 	this._getCachedCharacteristicAsync(
-			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
-		return rt.promisify(characteristic.readValueAsync, characteristic)().then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			let data = rt.toBuffer(result.value);
+		deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
+			return rt.promisify(characteristic.readValueAsync, characteristic)().then(result => {
+				checkCommunicationResult(deviceUuid, result);
+				let data = rt.toBuffer(result.value);
 
-			debug('  => [' + data.length + ']');
-			this.emit('read', deviceUuid, serviceUuid, characteristicUuid, data, false);
+				debug('  => [' + data.length + ']');
+				this.emit('read', deviceUuid, serviceUuid, characteristicUuid, data, false);
+			});
+		}).catch(ex => {
+			debug('failed to read characteristic for device %s: %s', deviceUuid, ex.stack);
+			this.emit('read', deviceUuid, serviceUuid, characteristicUuid, ex, false);
 		});
-	}).catch (ex => {
-		debug('failed to read characteristic for device %s: %s', deviceUuid, ex.stack);
-		this.emit('read', deviceUuid, serviceUuid, characteristicUuid, ex, false);
-	});
 };
 
 NobleBindings.prototype.write =
-		function(deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
-	debug('write(%s, %s, %s, (data), %s)',
-		deviceUuid, serviceUuid, characteristicUuid, withoutResponse);
+	function (deviceUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+		debug('write(%s, %s, %s, (data), %s)',
+			deviceUuid, serviceUuid, characteristicUuid, withoutResponse);
 
-	this._getCachedCharacteristicAsync(
+		this._getCachedCharacteristicAsync(
 			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
-		let rtBuffer = rt.fromBuffer(data);
-		return rt.promisify(characteristic.writeValueWithResultAsync, characteristic)(
-				rtBuffer).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
-		});
-	}).catch(ex => {
-		debug('failed to write characteristic for device %s: %s', deviceUuid, ex.stack);
-		if (!withoutResponse) {
-			this.emit('write', deviceUuid, serviceUuid, characteristicUuid, ex);
-		}
-	});
-};
+				let rtBuffer = rt.fromBuffer(data);
+				return rt.promisify(characteristic.writeValueWithResultAsync, characteristic)(
+					rtBuffer).then(result => {
+						checkCommunicationResult(deviceUuid, result);
+						this.emit('write', deviceUuid, serviceUuid, characteristicUuid);
+					});
+			}).catch(ex => {
+				debug('failed to write characteristic for device %s: %s', deviceUuid, ex.stack);
+				if (!withoutResponse) {
+					this.emit('write', deviceUuid, serviceUuid, characteristicUuid, ex);
+				}
+			});
+	};
 
 NobleBindings.prototype.broadcast =
-		function(deviceUuid, serviceUuid, characteristicUuid, broadcast) {
-	debug('broadcast(%s, %s, %s, %s)', deviceUuid, serviceUuid, + characteristicUuid, broadcast);
+	function (deviceUuid, serviceUuid, characteristicUuid, broadcast) {
+		debug('broadcast(%s, %s, %s, %s)', deviceUuid, serviceUuid, + characteristicUuid, broadcast);
 
-	this.emit('broadcast', deviceUuid, serviceUuid, characteristicUuid,
-		new Error('Not implemented'));
-};
+		this.emit('broadcast', deviceUuid, serviceUuid, characteristicUuid,
+			new Error('Not implemented'));
+	};
 
-NobleBindings.prototype.notify = function(deviceUuid, serviceUuid, characteristicUuid, notify) {
+NobleBindings.prototype.notify = function (deviceUuid, serviceUuid, characteristicUuid, notify) {
 	debug('notify(%s, %s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid, notify);
 
 	this._getCachedCharacteristicAsync(
-			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
-		let listenerKey = deviceUuid + '/' + serviceUuid + '/' + characteristicUuid;
-		let listener = this._listenerMap[listenerKey];
+		deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
+			let listenerKey = deviceUuid + '/' + serviceUuid + '/' + characteristicUuid;
+			let listener = this._listenerMap[listenerKey];
 
-		if (notify) {
-			if (listener) {
-				// Already listening.
-				this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
-				return;
-			}
-			
-			return rt.promisify(
+			if (notify) {
+				if (listener) {
+					// Already listening.
+					this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
+					return;
+				}
+
+				return rt.promisify(
 					characteristic.writeClientCharacteristicConfigurationDescriptorWithResultAsync,
 					characteristic)(GattClientCharacteristicConfigurationDescriptorValue.notify)
 					.then(result => {
-				checkCommunicationResult(deviceUuid, result);
+						checkCommunicationResult(deviceUuid, result);
 
-				listener = ((source, e) => {
-					debug('notification: %s %s %s', deviceUuid, serviceUuid, characteristicUuid);
-					let data = rt.toBuffer(e.characteristicValue);
-					this.emit('read', deviceUuid, serviceUuid, characteristicUuid, data, true);
-				}).bind(this);
+						listener = ((source, e) => {
+							debug('notification: %s %s %s', deviceUuid, serviceUuid, characteristicUuid);
+							let data = rt.toBuffer(e.characteristicValue);
+							this.emit('read', deviceUuid, serviceUuid, characteristicUuid, data, true);
+						}).bind(this);
 
-				characteristic.addListener('valueChanged', listener);
-				this._listenerMap[listenerKey] = listener;
-				this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
-			});
-		} else {
-			if (!listener) {
-				// Already not listening.
-				this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
-				return;
-			}
+						characteristic.addListener('valueChanged', listener);
+						this._listenerMap[listenerKey] = listener;
+						this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
+					});
+			} else {
+				if (!listener) {
+					// Already not listening.
+					this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
+					return;
+				}
 
-			characteristic.removeListener('valueChanged', listener);
-			delete this._listenerMap[listenerKey];
+				characteristic.removeListener('valueChanged', listener);
+				delete this._listenerMap[listenerKey];
 
-			return rt.promisify(
+				return rt.promisify(
 					characteristic.writeClientCharacteristicConfigurationDescriptorWithResultAsync,
 					characteristic)(GattClientCharacteristicConfigurationDescriptorValue.none)
 					.then(result => {
-				checkCommunicationResult(deviceUuid, result);
+						checkCommunicationResult(deviceUuid, result);
 
-				this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
-			});
-		}
-	}).catch(ex => {
-		debug('failed to enable characteristic notify for device %s: %s', deviceUuid, ex.stack);
-		this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, ex);
-	});
+						this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, notify);
+					});
+			}
+		}).catch(ex => {
+			debug('failed to enable characteristic notify for device %s: %s', deviceUuid, ex.stack);
+			this.emit('notify', deviceUuid, serviceUuid, characteristicUuid, ex);
+		});
 };
 
 NobleBindings.prototype.discoverDescriptors =
-		function(deviceUuid, serviceUuid, characteristicUuid) {
-	debug('discoverDescriptors(%s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid);
+	function (deviceUuid, serviceUuid, characteristicUuid) {
+		debug('discoverDescriptors(%s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid);
 
-	this._getCachedCharacteristicAsync(
+		this._getCachedCharacteristicAsync(
 			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
-		return rt.promisify(characteristic.getDescriptorsAsync, characteristic)(
-				BluetoothCacheMode.uncached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			
-			let descriptors = rt.toArray(result.descriptors).map(d => d.uuid);
-			this.emit('descriptorsDiscover', deviceUuid, serviceUuid, characteristicUuid, descriptors);
-		});
-	}).catch (ex => {
-		debug('failed to get GATT characteristic descriptors for device %s: %s',
-			deviceUuid, ex.stack);
-		this.emit('descriptorsDiscover', deviceUuid, serviceUuid, characteristicUuid, ex);
-	});
-};
+				return rt.promisify(characteristic.getDescriptorsAsync, characteristic)(
+					BluetoothCacheMode.uncached).then(result => {
+						checkCommunicationResult(deviceUuid, result);
+
+						let descriptors = rt.toArray(result.descriptors).map(d => d.uuid);
+						this.emit('descriptorsDiscover', deviceUuid, serviceUuid, characteristicUuid, descriptors);
+					});
+			}).catch(ex => {
+				debug('failed to get GATT characteristic descriptors for device %s: %s',
+					deviceUuid, ex.stack);
+				this.emit('descriptorsDiscover', deviceUuid, serviceUuid, characteristicUuid, ex);
+			});
+	};
 
 NobleBindings.prototype.readValue =
-		function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-	debug('readValue(%s, %s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
+	function (deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+		debug('readValue(%s, %s, %s, %s)', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
 
-	return this._getCachedDescriptorAsync(
+		return this._getCachedDescriptorAsync(
 			deviceUuid, serviceUuid, characteristicUuid, descriptorUuid).then(descriptor => {
-		return rt.promisify(descriptor.readValueAsync, descriptor)(
-				BluetoothCacheMode.uncached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			let data = rt.toBuffer(result.value);
+				return rt.promisify(descriptor.readValueAsync, descriptor)(
+					BluetoothCacheMode.uncached).then(result => {
+						checkCommunicationResult(deviceUuid, result);
+						let data = rt.toBuffer(result.value);
 
-			debug('  => [' + data.length + ']');
-			this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
-		});
-	}).catch (ex => {
-		debug('failed to read GATT characteristic descriptor values for device %s: %s', deviceUuid,
-			ex.stack);
-		this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
-	});
-};
+						debug('  => [' + data.length + ']');
+						this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+					});
+			}).catch(ex => {
+				debug('failed to read GATT characteristic descriptor values for device %s: %s', deviceUuid,
+					ex.stack);
+				this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
+			});
+	};
 
 NobleBindings.prototype.writeValue =
-		function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
-	debug('writeValue(%s, %s, %s, %s, (data))',
-		deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
+	function (deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+		debug('writeValue(%s, %s, %s, %s, (data))',
+			deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
 
-	this._getCachedDescriptorAsync(
+		this._getCachedDescriptorAsync(
 			deviceUuid, serviceUuid, characteristicUuid, descriptorUuid).then(descriptor => {
-		let rtBuffer = rt.fromBuffer(data);
-		return rt.promisify(descriptor.writeValueWithResultAsync, descriptor)(
-				rtBuffer).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
-		});
-	}).catch(ex => {
-		debug('failed to write characteristic descriptor for device %s: %s', deviceUuid, ex.stack);
-		if (!withoutResponse) {
-			this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
-		}
-	});
-};
+				let rtBuffer = rt.fromBuffer(data);
+				return rt.promisify(descriptor.writeValueWithResultAsync, descriptor)(
+					rtBuffer).then(result => {
+						checkCommunicationResult(deviceUuid, result);
+						this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
+					});
+			}).catch(ex => {
+				debug('failed to write characteristic descriptor for device %s: %s', deviceUuid, ex.stack);
+				if (!withoutResponse) {
+					this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
+				}
+			});
+	};
 
-NobleBindings.prototype.readHandle = function(deviceUuid, handle) {
+NobleBindings.prototype.readHandle = function (deviceUuid, handle) {
 	this.emit('readHandle', deviceUuid, handle, new Error('Not supported'));
 };
 
-NobleBindings.prototype.writeHandle = function(deviceUuid, handle, data, withoutResponse) {
+NobleBindings.prototype.writeHandle = function (deviceUuid, handle, data, withoutResponse) {
 	if (!withoutResponse) {
 		this.emit('writeHandle', deviceUuid, handle, new Error('Not supported'));
 	}
 };
 
-NobleBindings.prototype._updateRadioState = function() {
+NobleBindings.prototype._updateRadioState = function () {
 	let state;
 
 	if (!this._radio) {
@@ -454,14 +456,13 @@ NobleBindings.prototype._updateRadioState = function() {
 			state = 'unknown';
 			break;
 	}
-
 	if (state != this._radioState) {
 		this._radioState = state;
 		this.emit('stateChange', state);
 	}
 };
 
-NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
+NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 	let address = formatBluetoothAddress(e.bluetoothAddress);
 	debug('watcher received: %s %s %s',
 		getEnumName(BluetoothLEAdvertisementType, e.advertisementType),
@@ -471,32 +472,32 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 
 	let serviceUuids = undefined;
 	const isScanResponse = e.advertisementType === BluetoothLEAdvertisementType.scanResponse;
-	if (isScanResponse) {
+	if (this._acceptOnlyScanResponse && isScanResponse) {
 		if (!this._deviceMap[deviceUuid]) {
-			debug('    Ignoring scan response for unknown device');
+			debug('	Ignoring scan response for unknown device');
 			return;
 		}
 	} else {
 		if (!this._allowAdvertisementDuplicates && this._deviceMap[deviceUuid]) {
-			debug('    Ignoring duplicate advertisement');
+			debug('	Ignoring duplicate advertisement');
 			return;
 		}
 
 		let serviceUuidMatched = !this._filterAdvertisementServiceUuids;
 		serviceUuids = rt.toArray(e.advertisement.serviceUuids).map(serviceUuid => {
 			if (debug.enabled) {
-				debug('    service UUID: %s',
+				debug('	service UUID: %s',
 					(getEnumName(GattServiceUuids, serviceUuid) || uuidToString(serviceUuid)));
 			}
 			serviceUuid = uuidToString(serviceUuid);
 			if (!serviceUuidMatched &&
-					this._filterAdvertisementServiceUuids.indexOf(serviceUuid) >= 0) {
+				this._filterAdvertisementServiceUuids.indexOf(serviceUuid) >= 0) {
 				serviceUuidMatched = true;
 			}
 			return serviceUuid;
 		});
 		if (!serviceUuidMatched) {
-			debug('    Ignoring advertisement that did not pass service UUID filter');
+			debug('	Ignoring advertisement that did not pass service UUID filter');
 			return;
 		}
 	}
@@ -516,16 +517,16 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 			break;
 	}
 
-		// Random addresses have the two most-significant bits set of the 48-bit address.
+	// Random addresses have the two most-significant bits set of the 48-bit address.
 	let addressType = (e.bluetoothAddress >= (3 * Math.pow(2, 46)) ? 'random' : 'public');
-	debug('    address type: %s', addressType);
+	debug('	address type: %s', addressType);
 
 	let dataSections = rt.toArray(e.advertisement.dataSections);
 	let serviceDataEntry = {};
 	dataSections.forEach(dataSection => {
-		debug('    data section: %s',
+		debug('	data section: %s',
 			(getEnumName(BluetoothLEAdvertisementDataTypes, dataSection.dataType) ||
-			dataSection.dataType));
+				dataSection.dataType));
 		// https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile 
 		switch (dataSection.dataType) {
 			case BluetoothLEAdvertisementDataTypes.completeService16BitUuids:
@@ -540,14 +541,14 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 				break;
 			case BluetoothLEAdvertisementDataTypes.serviceData16BitUuids:
 				serviceDataEntry.data = rt.toBuffer(dataSection.data).slice(2);
-				break; 
+				break;
 			default:
 				break;
 		}
 	});
 
 	if (typeof e.advertisement.flags === 'number') {
-		debug('    advertisement flags: %s', e.advertisement.flags);
+		debug('	advertisement flags: %s', e.advertisement.flags);
 	}
 
 	let txPowerLevel = null;
@@ -589,8 +590,8 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 		let companyIdHex = manufacturerData.companyId.toString(16);
 		let toAppend = Buffer.allocUnsafe(2);
 		toAppend.writeUInt16LE(manufacturerData.companyId);
-		deviceRecord.manufacturerData = Buffer.concat([toAppend,  deviceRecord.manufacturerData]);
-		debug('    manufacturer data: %s', deviceRecord.manufacturerData.toString('hex'));
+		deviceRecord.manufacturerData = Buffer.concat([toAppend, deviceRecord.manufacturerData]);
+		debug('	manufacturer data: %s', deviceRecord.manufacturerData.toString('hex'));
 	}
 
 
@@ -599,7 +600,7 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 	}
 
 	// Wait until the response to the active query before emitting a 'discover' event.
-	if (isScanResponse) {
+	if (!this._acceptOnlyScanResponse || isScanResponse) {
 		let advertisement = {
 			localName: deviceRecord.name,
 			txPowerLevel: deviceRecord.txPowerLevel,
@@ -613,16 +614,16 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function(sender, e) {
 		debug('discover: %s [%s]', deviceUuid, advertisement.serviceUuids.join());
 		this.emit(
 			'discover',
-			 deviceUuid,
-			 address,
-			 deviceRecord.addressType,
-			 deviceRecord.connectable,
-			 advertisement,
-			 rssi);
+			deviceUuid,
+			address,
+			deviceRecord.addressType,
+			deviceRecord.connectable,
+			advertisement,
+			rssi);
 	}
 };
 
-NobleBindings.prototype._onAdvertisementWatcherStopped = function(sender, e) {
+NobleBindings.prototype._onAdvertisementWatcherStopped = function (sender, e) {
 	if (this._advertisementWatcher.status === BluetoothLEAdvertisementWatcherStatus.aborted) {
 		debug('watcher aborted');
 	} else if (this._advertisementWatcher.status === BluetoothLEAdvertisementWatcherStatus.stopped) {
@@ -630,9 +631,10 @@ NobleBindings.prototype._onAdvertisementWatcherStopped = function(sender, e) {
 	} else {
 		debug('watcher stopped with unexpected status: %s', this._advertisementWatcher.status);
 	}
+	this.emit('scanStop');
 };
 
-NobleBindings.prototype._onConnectionStatusChanged = function(sender, e) {
+NobleBindings.prototype._onConnectionStatusChanged = function (sender, e) {
 	const deviceUuid = sender.bluetoothAddress.toString(16);
 	const deviceRecord = this._deviceMap[deviceUuid];
 	if (deviceRecord) {
@@ -651,7 +653,7 @@ NobleBindings.prototype._onConnectionStatusChanged = function(sender, e) {
 	}
 };
 
-NobleBindings.prototype._getCachedServiceAsync = function(deviceUuid, serviceUuid) {
+NobleBindings.prototype._getCachedServiceAsync = function (deviceUuid, serviceUuid) {
 	let deviceRecord = this._deviceMap[deviceUuid];
 	if (!deviceRecord) {
 		throw new Error('Invalid or unknown device UUID: ' + deviceUuid);
@@ -668,77 +670,77 @@ NobleBindings.prototype._getCachedServiceAsync = function(deviceUuid, serviceUui
 	}
 
 	return rt.promisify(device.getGattServicesAsync, device)(
-			BluetoothCacheMode.cached).then(result => {
-		checkCommunicationResult(deviceUuid, result);
-		service = rt.trackDisposables(deviceUuid, rt.toArray(result.services))
-			.find(s => uuidToString(s.uuid) === serviceUuid);
-		if (!service) {
-			throw new Error('Service ' + serviceUuid + ' not found for device ' + deviceUuid);
-		}
-		deviceRecord.serviceMap[serviceUuid] = service;
-		return service;
-	});
+		BluetoothCacheMode.cached).then(result => {
+			checkCommunicationResult(deviceUuid, result);
+			service = rt.trackDisposables(deviceUuid, rt.toArray(result.services))
+				.find(s => uuidToString(s.uuid) === serviceUuid);
+			if (!service) {
+				throw new Error('Service ' + serviceUuid + ' not found for device ' + deviceUuid);
+			}
+			deviceRecord.serviceMap[serviceUuid] = service;
+			return service;
+		});
 };
 
 NobleBindings.prototype._getCachedCharacteristicAsync =
-		function(deviceUuid, serviceUuid, characteristicUuid) {
-	let deviceRecord = this._deviceMap[deviceUuid];
-	if (!deviceRecord) {
-		throw new Error('Invalid or unknown device UUID: ' + deviceUuid);
-	}
+	function (deviceUuid, serviceUuid, characteristicUuid) {
+		let deviceRecord = this._deviceMap[deviceUuid];
+		if (!deviceRecord) {
+			throw new Error('Invalid or unknown device UUID: ' + deviceUuid);
+		}
 
-	let characteristicKey = serviceUuid + '/' + characteristicUuid;
-	let characteristic = deviceRecord.characteristicMap[characteristicKey];
-	if (characteristic) {
-		return Promise.resolve(characteristic);
-	}
+		let characteristicKey = serviceUuid + '/' + characteristicUuid;
+		let characteristic = deviceRecord.characteristicMap[characteristicKey];
+		if (characteristic) {
+			return Promise.resolve(characteristic);
+		}
 
-	return this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
-		return rt.promisify(service.getCharacteristicsAsync, service)(
+		return this._getCachedServiceAsync(deviceUuid, serviceUuid).then(service => {
+			return rt.promisify(service.getCharacteristicsAsync, service)(
 				BluetoothCacheMode.cached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			characteristic = rt.toArray(result.characteristics)
-				.find(c => uuidToString(c.uuid) === characteristicUuid);
-			if (!characteristic) {
-				throw new Error('Service ' + serviceUuid + ' characteristic ' +
-					characteristicUuid + ' not found for device ' + deviceUuid);
-			}
-			deviceRecord.characteristicMap[characteristicKey] = characteristic;
-			return characteristic;
+					checkCommunicationResult(deviceUuid, result);
+					characteristic = rt.toArray(result.characteristics)
+						.find(c => uuidToString(c.uuid) === characteristicUuid);
+					if (!characteristic) {
+						throw new Error('Service ' + serviceUuid + ' characteristic ' +
+							characteristicUuid + ' not found for device ' + deviceUuid);
+					}
+					deviceRecord.characteristicMap[characteristicKey] = characteristic;
+					return characteristic;
+				});
 		});
-	});
-};
+	};
 
 NobleBindings.prototype._getCachedDescriptorAsync =
-		function(deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
-	let deviceRecord = this._deviceMap[deviceUuid];
-	if (!deviceRecord) {
-		throw new Error('Invalid or unknown device UUID: ' + deviceUuid);
-	}
+	function (deviceUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+		let deviceRecord = this._deviceMap[deviceUuid];
+		if (!deviceRecord) {
+			throw new Error('Invalid or unknown device UUID: ' + deviceUuid);
+		}
 
-	let descriptorKey = serviceUuid + '/' + characteristicUuid + '/' + descriptorUuid;
-	let descriptor = deviceRecord.descriptorMap[descriptorKey];
-	if (descriptor) {
-		return Promise.resolve(descriptor);
-	}
+		let descriptorKey = serviceUuid + '/' + characteristicUuid + '/' + descriptorUuid;
+		let descriptor = deviceRecord.descriptorMap[descriptorKey];
+		if (descriptor) {
+			return Promise.resolve(descriptor);
+		}
 
-	return this._getCachedCharacteristicAsync(
+		return this._getCachedCharacteristicAsync(
 			deviceUuid, serviceUuid, characteristicUuid).then(service => {
-		return rt.promisify(characteristic.getDescriptorsAsync, characteristic)(
-				BluetoothCacheMode.cached).then(result => {
-			checkCommunicationResult(deviceUuid, result);
-			descriptor = rt.toArray(result.descriptors)
-				.find(d => uuidToString(d.uuid) === descriptorUuid);
-			if (!descriptor) {
-				throw new Error('Service ' + serviceUuid + ' characteristic ' +
-					characteristicUuid + ' descriptor ' + descriptorUuid +
-					' not found for device ' + deviceUuid);
-			}
-			deviceRecord.descriptorMap[descriptorKey] = descriptor;
-			return descriptor;
-		});
-	});
-};
+				return rt.promisify(characteristic.getDescriptorsAsync, characteristic)(
+					BluetoothCacheMode.cached).then(result => {
+						checkCommunicationResult(deviceUuid, result);
+						descriptor = rt.toArray(result.descriptors)
+							.find(d => uuidToString(d.uuid) === descriptorUuid);
+						if (!descriptor) {
+							throw new Error('Service ' + serviceUuid + ' characteristic ' +
+								characteristicUuid + ' descriptor ' + descriptorUuid +
+								' not found for device ' + deviceUuid);
+						}
+						deviceRecord.descriptorMap[descriptorKey] = descriptor;
+						return descriptor;
+					});
+			});
+	};
 
 function formatBluetoothAddress(address) {
 	if (!address) {

--- a/lib/rt-utils.js
+++ b/lib/rt-utils.js
@@ -50,20 +50,20 @@ function promisify(fn, o) {
 
 // Convert a WinRT IVectorView to a JS Array.
 function toArray(o) {
-  let a = new Array(o.length);
-  for (let i = 0; i < a.length; i++) {
-    a[i] = o[i];
-  }
-  return a;
+	let a = new Array(o.length);
+	for (let i = 0; i < a.length; i++) {
+		a[i] = o[i];
+	}
+	return a;
 }
 
 // Convert a WinRT IMap to a JS Map.
 function toMap(o) {
-  let m = new Map();
-  for (let i = o.first(); i.hasCurrent; i.moveNext()) {
-	 m.set(i.current.key, i.current.value);
-  }
-  return m;
+	let m = new Map();
+	for (let i = o.first(); i.hasCurrent; i.moveNext()) {
+		m.set(i.current.key, i.current.value);
+	}
+	return m;
 }
 
 // Convert a WinRT IBuffer to a JS Buffer.
@@ -100,7 +100,7 @@ function keepAlive(k) {
 	if (k) {
 		if (++keepAliveIntervalCount === 1) {
 			// The actual duration doesn't really matter: it should be large but not too large.
-			keepAliveIntervalId = setInterval(() => {}, 24 * 60 * 60 * 1000);
+			keepAliveIntervalId = setInterval(() => { }, 24 * 60 * 60 * 1000);
 		}
 	} else {
 		if (--keepAliveIntervalCount === 0) {
@@ -146,7 +146,7 @@ function trackDisposables(key, array) {
 
 function disposeAll(key) {
 	const disposableList = disposableMap[key];
-	
+
 	if (!disposableList) {
 		return;
 	}

--- a/lib/uwpAddition.js
+++ b/lib/uwpAddition.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// NobleUWPAddition is to expand noble interface with additional features, known to be supported on UWP.
+
+const debug = require('debug')('noble-uwp');
+const rt = require('./rt-utils');
+
+// Note the load order here is important for cross-namespace dependencies.
+rt.using('Windows.Foundation');
+rt.using('Windows.Storage.Streams');
+rt.using('Windows.Devices.Enumeration');
+rt.using('Windows.Devices.Bluetooth.GenericAttributeProfile');
+rt.using('Windows.Devices.Bluetooth');
+rt.using('Windows.Devices.Bluetooth.Advertisement');
+rt.using('Windows.Devices.Radios');
+
+const BluetoothSignalStrengthFilter = Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter;
+
+let NobleUWPAddition = function () {
+	this.bindings = null;
+	this.init = function (bindings) {
+		this.bindings = bindings;
+	}
+	this.acceptOnlyScanResponse = function (value) {
+		if (!this.bindings) {
+			debug('bindings is not set, initialize this component.');
+			return;
+		}
+		this.bindings._acceptOnlyScanResponse = value;
+	}
+	this.setSignalFilter = function (inRangeThreshold, outOfRangeThreshold, outOfRangeTimeout, samplingInterval) {
+		try {
+			if (!this.bindings) {
+				debug('bindings is not set, initialize this component.');
+				return;
+			}
+			if (!this.bindings._advertisementWatcher) {
+				debug('AdvertisementWatcher is not set.');
+				return;
+			}
+			let signalFilter = new BluetoothSignalStrengthFilter();
+			signalFilter.inRangeThresholdInDBm = inRangeThreshold;
+			signalFilter.outOfRangeThresholdInDBm = outOfRangeThreshold;
+			signalFilter.outOfRangeTimeout = outOfRangeTimeout;
+			signalFilter.samplingInterval = samplingInterval;
+			this.bindings._advertisementWatcher.signalStrengthFilter = signalFilter;
+		} catch (error) {
+			debug('setSignalConfig error: ' + error.stack);
+		}
+	}
+}
+
+module.exports = new NobleUWPAddition();

--- a/lib/uwpAddition.js
+++ b/lib/uwpAddition.js
@@ -6,13 +6,7 @@ const debug = require('debug')('noble-uwp');
 const rt = require('./rt-utils');
 
 // Note the load order here is important for cross-namespace dependencies.
-rt.using('Windows.Foundation');
-rt.using('Windows.Storage.Streams');
-rt.using('Windows.Devices.Enumeration');
-rt.using('Windows.Devices.Bluetooth.GenericAttributeProfile');
 rt.using('Windows.Devices.Bluetooth');
-rt.using('Windows.Devices.Bluetooth.Advertisement');
-rt.using('Windows.Devices.Radios');
 
 const BluetoothSignalStrengthFilter = Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter;
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
 var noble = require('./index');
 
+// Flag to continuously scan advertisements
+const continuousScan = false;
+
 console.log('noble');
 
 noble.on('stateChange', function (state) {
@@ -25,7 +28,9 @@ noble.on('scanStop', function () {
 noble.on('discover', function (peripheral) {
 	console.log('on -> discover: ' + peripheral);
 
-	noble.stopScanning();
+	if (!continuousScan) {
+		noble.stopScanning();
+	}
 
 	peripheral.on('connect', function () {
 		console.log('on -> connect');
@@ -113,6 +118,10 @@ noble.on('discover', function (peripheral) {
 		services[serviceIndex].discoverIncludedServices();
 	});
 
-	peripheral.connect();
+	if (peripheral.connectable) {
+		peripheral.connect();
+	} else {
+		console.log(peripheral.id + ' is not connectable.');
+	}
 });
 

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ var noble = require('./index');
 
 console.log('noble');
 
-noble.on('stateChange', function(state) {
+noble.on('stateChange', function (state) {
 	console.log('on -> stateChange: ' + state);
 
 	if (state === 'poweredOn') {
@@ -12,87 +12,87 @@ noble.on('stateChange', function(state) {
 	}
 });
 
-noble.on('scanStart', function() {
+noble.on('scanStart', function () {
 	console.log('on -> scanStart');
 });
 
-noble.on('scanStop', function() {
+noble.on('scanStop', function () {
 	console.log('on -> scanStop');
 });
 
 
 
-noble.on('discover', function(peripheral) {
+noble.on('discover', function (peripheral) {
 	console.log('on -> discover: ' + peripheral);
 
 	noble.stopScanning();
 
-	peripheral.on('connect', function() {
+	peripheral.on('connect', function () {
 		console.log('on -> connect');
 		this.updateRssi();
 	});
 
-	peripheral.on('disconnect', function() {
+	peripheral.on('disconnect', function () {
 		console.log('on -> disconnect');
 	});
 
-	peripheral.on('rssiUpdate', function(rssi) {
+	peripheral.on('rssiUpdate', function (rssi) {
 		console.log('on -> RSSI update ' + rssi);
 		this.discoverServices();
 	});
 
-	peripheral.on('servicesDiscover', function(services) {
+	peripheral.on('servicesDiscover', function (services) {
 		console.log('on -> peripheral services discovered ' + services);
 
 		var serviceIndex = 0;
 
-		services[serviceIndex].on('includedServicesDiscover', function(includedServiceUuids) {
+		services[serviceIndex].on('includedServicesDiscover', function (includedServiceUuids) {
 			console.log('on -> service included services discovered ' + includedServiceUuids);
 			this.discoverCharacteristics();
 		});
 
-		services[serviceIndex].on('characteristicsDiscover', function(characteristics) {
+		services[serviceIndex].on('characteristicsDiscover', function (characteristics) {
 			console.log('on -> service characteristics discovered ' + characteristics);
 
 			var characteristicIndex = 0;
 
-			characteristics[characteristicIndex].on('read', function(data, isNotification) {
+			characteristics[characteristicIndex].on('read', function (data, isNotification) {
 				console.log('on -> characteristic read ' + data + ' ' + isNotification);
 				console.log(data);
 
 				peripheral.disconnect();
 			});
 
-			characteristics[characteristicIndex].on('write', function() {
+			characteristics[characteristicIndex].on('write', function () {
 				console.log('on -> characteristic write ');
 
 				peripheral.disconnect();
 			});
 
-			characteristics[characteristicIndex].on('broadcast', function(state) {
+			characteristics[characteristicIndex].on('broadcast', function (state) {
 				console.log('on -> characteristic broadcast ' + state);
 
 				peripheral.disconnect();
 			});
 
-			characteristics[characteristicIndex].on('notify', function(state) {
+			characteristics[characteristicIndex].on('notify', function (state) {
 				console.log('on -> characteristic notify ' + state);
 
 				peripheral.disconnect();
 			});
 
-			characteristics[characteristicIndex].on('descriptorsDiscover', function(descriptors) {
+			characteristics[characteristicIndex].on('descriptorsDiscover', function (descriptors) {
 				console.log('on -> descriptors discover ' + descriptors);
 
 				var descriptorIndex = 0;
 
-				descriptors[descriptorIndex].on('valueRead', function(data) {
+				descriptors[descriptorIndex].on('valueRead', function (data) {
 					console.log('on -> descriptor value read ' + data);
 					console.log(data);
 					peripheral.disconnect();
 				});
 
-				descriptors[descriptorIndex].on('valueWrite', function() {
+				descriptors[descriptorIndex].on('valueWrite', function () {
 					console.log('on -> descriptor value write ');
 					peripheral.disconnect();
 				});
@@ -109,7 +109,7 @@ noble.on('discover', function(peripheral) {
 			// characteristics[characteristicIndex].discoverDescriptors();
 		});
 
-		
+
 		services[serviceIndex].discoverIncludedServices();
 	});
 


### PR DESCRIPTION
1. Lack of signal strength filtering restricts noble-uwp itself.
2. As is, noble-uwp is only reporting explicit scan responses and won't report passive advertisements. Setting a flag for this feature.
3. For 1 and 2, I wanted the noble itself to have an entry point that goes beyond noble interface. Hence the .uwp extension.
4. Some formatting unification
5. Investigating a bug around shutdown (NodeRT subscription hanging around after object destruction), not relevant to this PR, but is also a concern.
Would welcome feedback and other suggestions.