### PR TITLE
Fix descriptor bug.

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -402,12 +402,12 @@ NobleBindings.prototype.readValue =
 						let data = rt.toBuffer(result.value);
 
 						debug('  => [' + data.length + ']');
-						this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+						this.emit('valueRead', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
 					});
 			}).catch(ex => {
 				debug('failed to read GATT characteristic descriptor values for device %s: %s', deviceUuid,
 					ex.stack);
-				this.emit('readValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
+				this.emit('valueRead', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
 			});
 	};
 
@@ -422,12 +422,12 @@ NobleBindings.prototype.writeValue =
 				return rt.promisify(descriptor.writeValueWithResultAsync, descriptor)(
 					rtBuffer).then(result => {
 						checkCommunicationResult(deviceUuid, result);
-						this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
+						this.emit('valueWrite', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid);
 					});
 			}).catch(ex => {
 				debug('failed to write characteristic descriptor for device %s: %s', deviceUuid, ex.stack);
 				if (!withoutResponse) {
-					this.emit('writeValue', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
+					this.emit('valueWrite', deviceUuid, serviceUuid, characteristicUuid, descriptorUuid, ex);
 				}
 			});
 	};

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -380,7 +380,7 @@ NobleBindings.prototype.discoverDescriptors =
 					BluetoothCacheMode.uncached).then(result => {
 						checkCommunicationResult(deviceUuid, result);
 
-						let descriptors = rt.toArray(result.descriptors).map(d => d.uuid);
+						let descriptors = rt.toArray(result.descriptors).map(d => uuidToString(d.uuid));
 						this.emit('descriptorsDiscover', deviceUuid, serviceUuid, characteristicUuid, descriptors);
 					});
 			}).catch(ex => {

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -734,7 +734,7 @@ NobleBindings.prototype._getCachedDescriptorAsync =
 		}
 
 		return this._getCachedCharacteristicAsync(
-			deviceUuid, serviceUuid, characteristicUuid).then(service => {
+			deviceUuid, serviceUuid, characteristicUuid).then(characteristic => {
 				return rt.promisify(characteristic.getDescriptorsAsync, characteristic)(
 					BluetoothCacheMode.cached).then(result => {
 						checkCommunicationResult(deviceUuid, result);


### PR DESCRIPTION
I realized that descriptor have some bugs.
[Fixed bug]
- descriptor uuids are not correct.(Fixed in b817205)
noble returns descriptor uuid = "XXXX"
but noble-uwp returns   uuid = "{YYYYY-XXXX-YYYYY-YYYYY-YYYYY}"
- `characteristic` returned from promise incorrectory named `service`(Fixed in bf93e9c)
- descriptor's read and write event name are incorrect. (Fixed in 37bb011)
noble emit `valueWrite` event when descriptor wrote.
but noble-uwp emit `writeValue`.
Sorry for my poor english. Feel free to ask me about change.
