### PR TITLE
Fix electron native build failure in electron 5.0.

### DIFF
--- a/uwp/windows.devices.bluetooth.advertisement/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth.advertisement/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.devices.bluetooth.advertisement/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth.advertisement/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.devices.bluetooth.advertisement/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth.advertisement/_nodert_generated.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -59,47 +58,47 @@ using Nan::HandleScope;
 using Nan::TryCatch;
 using namespace concurrency;
 
-namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth { namespace Advertisement { 
+namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth { namespace Advertisement {
 
   v8::Local<v8::Value> WrapBluetoothLEManufacturerData(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ UnwrapBluetoothLEManufacturerData(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementDataSection(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ UnwrapBluetoothLEAdvertisementDataSection(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisement(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ UnwrapBluetoothLEAdvertisement(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementBytePattern(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^ UnwrapBluetoothLEAdvertisementBytePattern(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementFilter(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ UnwrapBluetoothLEAdvertisementFilter(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementWatcherStoppedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^ UnwrapBluetoothLEAdvertisementWatcherStoppedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementWatcher(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^ UnwrapBluetoothLEAdvertisementWatcher(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementReceivedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^ UnwrapBluetoothLEAdvertisementReceivedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementDataTypes(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^ UnwrapBluetoothLEAdvertisementDataTypes(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementPublisherStatusChangedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^ UnwrapBluetoothLEAdvertisementPublisherStatusChangedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAdvertisementPublisher(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^ wintRtInstance);
   ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^ UnwrapBluetoothLEAdvertisementPublisher(Local<Value> value);
-  
+
 
 
   static void InitBluetoothLEScanningModeEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothLEScanningMode").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("passive").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEScanningMode::Passive)));
@@ -110,7 +109,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothLEAdvertisementFlagsEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothLEAdvertisementFlags").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("none").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFlags::None)));
@@ -125,7 +124,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothLEAdvertisementTypeEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothLEAdvertisementType").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("connectableUndirected").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementType::ConnectableUndirected)));
@@ -139,7 +138,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothLEAdvertisementWatcherStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothLEAdvertisementWatcherStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("created").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStatus::Created)));
@@ -153,7 +152,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothLEAdvertisementPublisherStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothLEAdvertisementPublisherStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("created").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatus::Created)));
@@ -166,23 +165,23 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
 
 
-  
+
   class BluetoothLEManufacturerData : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEManufacturerData").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("data").ToLocalChecked(), DataGetter, DataSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("companyId").ToLocalChecked(), CompanyIdGetter, CompanyIdSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -197,13 +196,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEManufacturerData(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -242,14 +241,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -279,7 +278,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           unsigned short arg0 = static_cast<unsigned short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Storage::Streams::IBuffer^ arg1 = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(info[1]));
-          
+
           winRtInstance = ref new ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -303,7 +302,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -328,14 +327,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void DataGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>(info.This()))
       {
         return;
@@ -343,7 +342,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEManufacturerData *wrapper = BluetoothLEManufacturerData::Unwrap<BluetoothLEManufacturerData>(info.This());
 
-      try 
+      try
       {
         ::Windows::Storage::Streams::IBuffer^ result = wrapper->_instance->Data;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IBuffer", result));
@@ -355,11 +354,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DataSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Storage::Streams::IBuffer^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -373,9 +372,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEManufacturerData *wrapper = BluetoothLEManufacturerData::Unwrap<BluetoothLEManufacturerData>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Storage::Streams::IBuffer^ winRtValue = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->Data = winRtValue;
@@ -385,11 +384,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void CompanyIdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>(info.This()))
       {
         return;
@@ -397,7 +396,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEManufacturerData *wrapper = BluetoothLEManufacturerData::Unwrap<BluetoothLEManufacturerData>(info.This());
 
-      try 
+      try
       {
         unsigned short result = wrapper->_instance->CompanyId;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -409,11 +408,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CompanyIdSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -427,9 +426,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEManufacturerData *wrapper = BluetoothLEManufacturerData::Unwrap<BluetoothLEManufacturerData>(info.This());
 
-      try 
+      try
       {
-        
+
         unsigned short winRtValue = static_cast<unsigned short>(Nan::To<int32_t>(value).FromMaybe(0));
 
         wrapper->_instance->CompanyId = winRtValue;
@@ -439,7 +438,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -478,20 +477,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementDataSection : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementDataSection").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("dataType").ToLocalChecked(), DataTypeGetter, DataTypeSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("data").ToLocalChecked(), DataGetter, DataSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -506,13 +505,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementDataSection(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -551,14 +550,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -588,7 +587,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           unsigned char arg0 = static_cast<unsigned char>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Storage::Streams::IBuffer^ arg1 = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(info[1]));
-          
+
           winRtInstance = ref new ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -612,7 +611,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -637,14 +636,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void DataTypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>(info.This()))
       {
         return;
@@ -652,7 +651,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementDataSection *wrapper = BluetoothLEAdvertisementDataSection::Unwrap<BluetoothLEAdvertisementDataSection>(info.This());
 
-      try 
+      try
       {
         unsigned char result = wrapper->_instance->DataType;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -664,11 +663,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DataTypeSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -682,9 +681,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementDataSection *wrapper = BluetoothLEAdvertisementDataSection::Unwrap<BluetoothLEAdvertisementDataSection>(info.This());
 
-      try 
+      try
       {
-        
+
         unsigned char winRtValue = static_cast<unsigned char>(Nan::To<int32_t>(value).FromMaybe(0));
 
         wrapper->_instance->DataType = winRtValue;
@@ -694,11 +693,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void DataGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>(info.This()))
       {
         return;
@@ -706,7 +705,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementDataSection *wrapper = BluetoothLEAdvertisementDataSection::Unwrap<BluetoothLEAdvertisementDataSection>(info.This());
 
-      try 
+      try
       {
         ::Windows::Storage::Streams::IBuffer^ result = wrapper->_instance->Data;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IBuffer", result));
@@ -718,11 +717,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DataSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Storage::Streams::IBuffer^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -736,9 +735,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementDataSection *wrapper = BluetoothLEAdvertisementDataSection::Unwrap<BluetoothLEAdvertisementDataSection>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Storage::Streams::IBuffer^ winRtValue = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->Data = winRtValue;
@@ -748,7 +747,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -787,27 +786,27 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisement : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisement").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getManufacturerDataByCompanyId", GetManufacturerDataByCompanyId);
       Nan::SetPrototypeMethod(localRef, "getSectionsByType", GetSectionsByType);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("localName").ToLocalChecked(), LocalNameGetter, LocalNameSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("flags").ToLocalChecked(), FlagsGetter, FlagsSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("dataSections").ToLocalChecked(), DataSectionsGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("manufacturerData").ToLocalChecked(), ManufacturerDataGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("serviceUuids").ToLocalChecked(), ServiceUuidsGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -822,13 +821,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisement(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -867,14 +866,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -911,7 +910,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -936,7 +935,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
     static void GetManufacturerDataByCompanyId(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -954,10 +953,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned short arg0 = static_cast<unsigned short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>^ result;
           result = wrapper->_instance->GetManufacturerDataByCompanyId(arg0);
-          info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>::CreateVectorViewWrapper(result, 
+          info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ val) -> Local<Value> {
               return WrapBluetoothLEManufacturerData(val);
             },
@@ -976,7 +975,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -999,10 +998,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned char arg0 = static_cast<unsigned char>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>^ result;
           result = wrapper->_instance->GetSectionsByType(arg0);
-          info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>::CreateVectorViewWrapper(result, 
+          info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ val) -> Local<Value> {
               return WrapBluetoothLEAdvertisementDataSection(val);
             },
@@ -1021,7 +1020,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1033,7 +1032,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void LocalNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info.This()))
       {
         return;
@@ -1041,7 +1040,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->LocalName;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -1053,11 +1052,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void LocalNameSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsString())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1071,9 +1070,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
-        
+
         Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
 
         wrapper->_instance->LocalName = winRtValue;
@@ -1083,11 +1082,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void FlagsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info.This()))
       {
         return;
@@ -1095,7 +1094,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
         ::Platform::IBox<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFlags>^ result = wrapper->_instance->Flags;
         info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Integer>(static_cast<int>(result->Value))) : Undefined());
@@ -1107,11 +1106,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void FlagsSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1125,9 +1124,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Platform::IBox<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFlags>^ winRtValue = ref new ::Platform::Box<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFlags>(static_cast<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFlags>(Nan::To<int32_t>(value).FromMaybe(0)));
 
         wrapper->_instance->Flags = winRtValue;
@@ -1137,11 +1136,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void DataSectionsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info.This()))
       {
         return;
@@ -1149,10 +1148,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>^ result = wrapper->_instance->DataSections;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^>::CreateVectorWrapper(result,
             [](::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataSection^ val) -> Local<Value> {
               return WrapBluetoothLEAdvertisementDataSection(val);
             },
@@ -1171,11 +1170,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ManufacturerDataGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info.This()))
       {
         return;
@@ -1183,10 +1182,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>^ result = wrapper->_instance->ManufacturerData;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^>::CreateVectorWrapper(result,
             [](::Windows::Devices::Bluetooth::Advertisement::BluetoothLEManufacturerData^ val) -> Local<Value> {
               return WrapBluetoothLEManufacturerData(val);
             },
@@ -1205,11 +1204,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(info.This()))
       {
         return;
@@ -1217,10 +1216,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisement *wrapper = BluetoothLEAdvertisement::Unwrap<BluetoothLEAdvertisement>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Platform::Guid>^ result = wrapper->_instance->ServiceUuids;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::Guid>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::Guid>::CreateVectorWrapper(result,
             [](::Platform::Guid val) -> Local<Value> {
               return NodeRT::Utils::GuidToJs(val);
             },
@@ -1239,7 +1238,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -1278,21 +1277,21 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementBytePattern : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementBytePattern").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("offset").ToLocalChecked(), OffsetGetter, OffsetSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("dataType").ToLocalChecked(), DataTypeGetter, DataTypeSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("data").ToLocalChecked(), DataGetter, DataSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1307,13 +1306,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementBytePattern(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1352,14 +1351,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1391,7 +1390,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           unsigned char arg0 = static_cast<unsigned char>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           short arg1 = static_cast<short>(Nan::To<int32_t>(info[1]).FromMaybe(0));
           ::Windows::Storage::Streams::IBuffer^ arg2 = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(info[2]));
-          
+
           winRtInstance = ref new ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern(arg0,arg1,arg2);
         }
         catch (Platform::Exception ^exception)
@@ -1415,7 +1414,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1440,14 +1439,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void OffsetGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>(info.This()))
       {
         return;
@@ -1455,7 +1454,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
         short result = wrapper->_instance->Offset;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -1467,11 +1466,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OffsetSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1485,9 +1484,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
-        
+
         short winRtValue = static_cast<short>(Nan::To<int32_t>(value).FromMaybe(0));
 
         wrapper->_instance->Offset = winRtValue;
@@ -1497,11 +1496,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void DataTypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>(info.This()))
       {
         return;
@@ -1509,7 +1508,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
         unsigned char result = wrapper->_instance->DataType;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -1521,11 +1520,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DataTypeSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1539,9 +1538,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
-        
+
         unsigned char winRtValue = static_cast<unsigned char>(Nan::To<int32_t>(value).FromMaybe(0));
 
         wrapper->_instance->DataType = winRtValue;
@@ -1551,11 +1550,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void DataGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>(info.This()))
       {
         return;
@@ -1563,7 +1562,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
         ::Windows::Storage::Streams::IBuffer^ result = wrapper->_instance->Data;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IBuffer", result));
@@ -1575,11 +1574,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DataSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Storage::Streams::IBuffer^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1593,9 +1592,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementBytePattern *wrapper = BluetoothLEAdvertisementBytePattern::Unwrap<BluetoothLEAdvertisementBytePattern>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Storage::Streams::IBuffer^ winRtValue = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->Data = winRtValue;
@@ -1605,7 +1604,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -1644,20 +1643,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementFilter : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementFilter").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("advertisement").ToLocalChecked(), AdvertisementGetter, AdvertisementSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bytePatterns").ToLocalChecked(), BytePatternsGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1672,13 +1671,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementFilter(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1717,14 +1716,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1761,7 +1760,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1786,14 +1785,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void AdvertisementGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^>(info.This()))
       {
         return;
@@ -1801,7 +1800,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementFilter *wrapper = BluetoothLEAdvertisementFilter::Unwrap<BluetoothLEAdvertisementFilter>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ result = wrapper->_instance->Advertisement;
         info.GetReturnValue().Set(WrapBluetoothLEAdvertisement(result));
@@ -1813,11 +1812,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void AdvertisementSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1831,9 +1830,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementFilter *wrapper = BluetoothLEAdvertisementFilter::Unwrap<BluetoothLEAdvertisementFilter>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ winRtValue = dynamic_cast<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->Advertisement = winRtValue;
@@ -1843,11 +1842,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void BytePatternsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^>(info.This()))
       {
         return;
@@ -1855,10 +1854,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementFilter *wrapper = BluetoothLEAdvertisementFilter::Unwrap<BluetoothLEAdvertisementFilter>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>^ result = wrapper->_instance->BytePatterns;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^>::CreateVectorWrapper(result,
             [](::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementBytePattern^ val) -> Local<Value> {
               return WrapBluetoothLEAdvertisementBytePattern(val);
             },
@@ -1877,7 +1876,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -1916,19 +1915,19 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementWatcherStoppedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementWatcherStoppedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("error").ToLocalChecked(), ErrorGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1943,13 +1942,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementWatcherStoppedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1988,14 +1987,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2020,7 +2019,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2045,14 +2044,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void ErrorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStoppedEventArgs^>(info.This()))
       {
         return;
@@ -2060,7 +2059,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcherStoppedEventArgs *wrapper = BluetoothLEAdvertisementWatcherStoppedEventArgs::Unwrap<BluetoothLEAdvertisementWatcherStoppedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothError result = wrapper->_instance->Error;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -2072,7 +2071,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -2111,26 +2110,26 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementWatcher : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementWatcher").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "start", Start);
       Nan::SetPrototypeMethod(localRef, "stop", Stop);
-      
-                  
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("signalStrengthFilter").ToLocalChecked(), SignalStrengthFilterGetter, SignalStrengthFilterSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("scanningMode").ToLocalChecked(), ScanningModeGetter, ScanningModeSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("advertisementFilter").ToLocalChecked(), AdvertisementFilterGetter, AdvertisementFilterSetter);
@@ -2139,7 +2138,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("minOutOfRangeTimeout").ToLocalChecked(), MinOutOfRangeTimeoutGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("minSamplingInterval").ToLocalChecked(), MinSamplingIntervalGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2154,13 +2153,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementWatcher(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2199,14 +2198,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2234,7 +2233,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ arg0 = UnwrapBluetoothLEAdvertisementFilter(info[0]);
-          
+
           winRtInstance = ref new ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -2258,7 +2257,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2283,7 +2282,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
     static void Start(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2300,7 +2299,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           wrapper->_instance->Start();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2308,7 +2307,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2330,7 +2329,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           wrapper->_instance->Stop();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2338,7 +2337,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2350,7 +2349,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void SignalStrengthFilterGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2358,7 +2357,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ result = wrapper->_instance->SignalStrengthFilter;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Bluetooth", "BluetoothSignalStrengthFilter", result));
@@ -2370,11 +2369,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SignalStrengthFilterSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -2388,9 +2387,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ winRtValue = dynamic_cast<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->SignalStrengthFilter = winRtValue;
@@ -2400,11 +2399,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void ScanningModeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2412,7 +2411,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEScanningMode result = wrapper->_instance->ScanningMode;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -2424,11 +2423,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ScanningModeSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -2442,9 +2441,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEScanningMode winRtValue = static_cast<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEScanningMode>(Nan::To<int32_t>(value).FromMaybe(0));
 
         wrapper->_instance->ScanningMode = winRtValue;
@@ -2454,11 +2453,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void AdvertisementFilterGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2466,7 +2465,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ result = wrapper->_instance->AdvertisementFilter;
         info.GetReturnValue().Set(WrapBluetoothLEAdvertisementFilter(result));
@@ -2478,11 +2477,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void AdvertisementFilterSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -2496,9 +2495,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^ winRtValue = dynamic_cast<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementFilter^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->AdvertisementFilter = winRtValue;
@@ -2508,11 +2507,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void MaxOutOfRangeTimeoutGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2520,7 +2519,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::TimeSpan result = wrapper->_instance->MaxOutOfRangeTimeout;
         info.GetReturnValue().Set(Nan::New<Number>(result.Duration/10000.0));
@@ -2532,11 +2531,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MaxSamplingIntervalGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2544,7 +2543,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::TimeSpan result = wrapper->_instance->MaxSamplingInterval;
         info.GetReturnValue().Set(Nan::New<Number>(result.Duration/10000.0));
@@ -2556,11 +2555,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MinOutOfRangeTimeoutGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2568,7 +2567,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::TimeSpan result = wrapper->_instance->MinOutOfRangeTimeout;
         info.GetReturnValue().Set(Nan::New<Number>(result.Duration/10000.0));
@@ -2580,11 +2579,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MinSamplingIntervalGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2592,7 +2591,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::TimeSpan result = wrapper->_instance->MinSamplingInterval;
         info.GetReturnValue().Set(Nan::New<Number>(result.Duration/10000.0));
@@ -2604,11 +2603,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcher^>(info.This()))
       {
         return;
@@ -2616,7 +2615,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementWatcherStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -2628,7 +2627,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2643,9 +2642,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"received", str))
       {
@@ -2655,12 +2654,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2712,12 +2711,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEAdvertisementWatcher *wrapper = BluetoothLEAdvertisementWatcher::Unwrap<BluetoothLEAdvertisementWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2761,7 +2760,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -2804,7 +2803,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -2818,12 +2817,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"received", str))
         {
@@ -2889,23 +2888,23 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementReceivedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementReceivedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("advertisement").ToLocalChecked(), AdvertisementGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("advertisementType").ToLocalChecked(), AdvertisementTypeGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bluetoothAddress").ToLocalChecked(), BluetoothAddressGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("rawSignalStrengthInDBm").ToLocalChecked(), RawSignalStrengthInDBmGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("timestamp").ToLocalChecked(), TimestampGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2920,13 +2919,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementReceivedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2965,14 +2964,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2997,7 +2996,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3022,14 +3021,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void AdvertisementGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info.This()))
       {
         return;
@@ -3037,7 +3036,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementReceivedEventArgs *wrapper = BluetoothLEAdvertisementReceivedEventArgs::Unwrap<BluetoothLEAdvertisementReceivedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ result = wrapper->_instance->Advertisement;
         info.GetReturnValue().Set(WrapBluetoothLEAdvertisement(result));
@@ -3049,11 +3048,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void AdvertisementTypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info.This()))
       {
         return;
@@ -3061,7 +3060,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementReceivedEventArgs *wrapper = BluetoothLEAdvertisementReceivedEventArgs::Unwrap<BluetoothLEAdvertisementReceivedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementType result = wrapper->_instance->AdvertisementType;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3073,11 +3072,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void BluetoothAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info.This()))
       {
         return;
@@ -3085,7 +3084,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementReceivedEventArgs *wrapper = BluetoothLEAdvertisementReceivedEventArgs::Unwrap<BluetoothLEAdvertisementReceivedEventArgs>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->BluetoothAddress;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -3097,11 +3096,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RawSignalStrengthInDBmGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info.This()))
       {
         return;
@@ -3109,7 +3108,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementReceivedEventArgs *wrapper = BluetoothLEAdvertisementReceivedEventArgs::Unwrap<BluetoothLEAdvertisementReceivedEventArgs>(info.This());
 
-      try 
+      try
       {
         short result = wrapper->_instance->RawSignalStrengthInDBm;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3121,11 +3120,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void TimestampGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementReceivedEventArgs^>(info.This()))
       {
         return;
@@ -3133,7 +3132,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementReceivedEventArgs *wrapper = BluetoothLEAdvertisementReceivedEventArgs::Unwrap<BluetoothLEAdvertisementReceivedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::DateTime result = wrapper->_instance->Timestamp;
         info.GetReturnValue().Set(NodeRT::Utils::DateTimeToJS(result));
@@ -3145,7 +3144,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -3184,17 +3183,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementDataTypes : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementDataTypes").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3231,13 +3230,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementDataTypes(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3276,14 +3275,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3308,7 +3307,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3333,7 +3332,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
@@ -3342,7 +3341,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::AdvertisingInterval;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3354,12 +3353,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void AppearanceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::Appearance;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3371,12 +3370,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CompleteLocalNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::CompleteLocalName;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3388,12 +3387,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CompleteService128BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::CompleteService128BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3405,12 +3404,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CompleteService16BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::CompleteService16BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3422,12 +3421,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CompleteService32BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::CompleteService32BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3439,12 +3438,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void FlagsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::Flags;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3456,12 +3455,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IncompleteService128BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::IncompleteService128BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3473,12 +3472,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IncompleteService16BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::IncompleteService16BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3490,12 +3489,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IncompleteService32BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::IncompleteService32BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3507,12 +3506,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ManufacturerSpecificDataGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ManufacturerSpecificData;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3524,12 +3523,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void PublicTargetAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::PublicTargetAddress;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3541,12 +3540,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RandomTargetAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::RandomTargetAddress;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3558,12 +3557,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceData128BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceData128BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3575,12 +3574,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceData16BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceData16BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3592,12 +3591,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceData32BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceData32BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3609,12 +3608,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceSolicitation128BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceSolicitation128BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3626,12 +3625,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceSolicitation16BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceSolicitation16BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3643,12 +3642,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceSolicitation32BitUuidsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ServiceSolicitation32BitUuids;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3660,12 +3659,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ShortenedLocalNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::ShortenedLocalName;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3677,12 +3676,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SlaveConnectionIntervalRangeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::SlaveConnectionIntervalRange;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3694,12 +3693,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void TxPowerLevelGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned char result = ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes::TxPowerLevel;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3711,7 +3710,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
   private:
     ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementDataTypes^ _instance;
@@ -3749,20 +3748,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementPublisherStatusChangedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementPublisherStatusChangedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("error").ToLocalChecked(), ErrorGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3777,13 +3776,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementPublisherStatusChangedEventArgs(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3822,14 +3821,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3854,7 +3853,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3879,14 +3878,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void ErrorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^>(info.This()))
       {
         return;
@@ -3894,7 +3893,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementPublisherStatusChangedEventArgs *wrapper = BluetoothLEAdvertisementPublisherStatusChangedEventArgs::Unwrap<BluetoothLEAdvertisementPublisherStatusChangedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothError result = wrapper->_instance->Error;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3906,11 +3905,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatusChangedEventArgs^>(info.This()))
       {
         return;
@@ -3918,7 +3917,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementPublisherStatusChangedEventArgs *wrapper = BluetoothLEAdvertisementPublisherStatusChangedEventArgs::Unwrap<BluetoothLEAdvertisementPublisherStatusChangedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3930,7 +3929,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -3969,29 +3968,29 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAdvertisementPublisher : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAdvertisementPublisher").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "start", Start);
       Nan::SetPrototypeMethod(localRef, "stop", Stop);
-      
-                  
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("advertisement").ToLocalChecked(), AdvertisementGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4006,13 +4005,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAdvertisementPublisher(::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4051,14 +4050,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4086,7 +4085,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ arg0 = UnwrapBluetoothLEAdvertisement(info[0]);
-          
+
           winRtInstance = ref new ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -4110,7 +4109,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4135,7 +4134,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
     static void Start(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4152,7 +4151,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           wrapper->_instance->Start();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -4160,7 +4159,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4182,7 +4181,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           wrapper->_instance->Stop();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -4190,7 +4189,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4202,7 +4201,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void AdvertisementGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^>(info.This()))
       {
         return;
@@ -4210,7 +4209,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementPublisher *wrapper = BluetoothLEAdvertisementPublisher::Unwrap<BluetoothLEAdvertisementPublisher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisement^ result = wrapper->_instance->Advertisement;
         info.GetReturnValue().Set(WrapBluetoothLEAdvertisement(result));
@@ -4222,11 +4221,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisher^>(info.This()))
       {
         return;
@@ -4234,7 +4233,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAdvertisementPublisher *wrapper = BluetoothLEAdvertisementPublisher::Unwrap<BluetoothLEAdvertisementPublisher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::Advertisement::BluetoothLEAdvertisementPublisherStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -4246,7 +4245,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -4261,9 +4260,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"statusChanged", str))
       {
@@ -4273,12 +4272,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEAdvertisementPublisher *wrapper = BluetoothLEAdvertisementPublisher::Unwrap<BluetoothLEAdvertisementPublisher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4322,7 +4321,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -4365,7 +4364,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -4379,12 +4378,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"statusChanged", str))
         {
@@ -4438,7 +4437,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     BluetoothLEAdvertisementPublisher::Init(exports);
   }
 
-} } } } } 
+} } } } }
 
 NAN_MODULE_INIT(init)
 {
@@ -4449,7 +4448,7 @@ NAN_MODULE_INIT(init)
     Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"error in CoInitializeEx()")));
     return;
   }*/
-  
+
   NodeRT::Windows::Devices::Bluetooth::Advertisement::InitBluetoothLEScanningModeEnum(target);
   NodeRT::Windows::Devices::Bluetooth::Advertisement::InitBluetoothLEAdvertisementFlagsEnum(target);
   NodeRT::Windows::Devices::Bluetooth::Advertisement::InitBluetoothLEAdvertisementTypeEnum(target);

--- a/uwp/windows.devices.bluetooth.advertisement/node-async.h
+++ b/uwp/windows.devices.bluetooth.advertisement/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.devices.bluetooth.advertisement/node-async.h
+++ b/uwp/windows.devices.bluetooth.advertisement/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/node-async.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/node-async.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.devices.bluetooth/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.devices.bluetooth/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.devices.bluetooth/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth/_nodert_generated.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -60,44 +59,44 @@ using Nan::HandleScope;
 using Nan::TryCatch;
 using namespace concurrency;
 
-namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth { 
+namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   v8::Local<v8::Value> WrapBluetoothAdapter(::Windows::Devices::Bluetooth::BluetoothAdapter^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothAdapter^ UnwrapBluetoothAdapter(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothDeviceId(::Windows::Devices::Bluetooth::BluetoothDeviceId^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothDeviceId^ UnwrapBluetoothDeviceId(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothUuidHelper(::Windows::Devices::Bluetooth::BluetoothUuidHelper^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothUuidHelper^ UnwrapBluetoothUuidHelper(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothDevice(::Windows::Devices::Bluetooth::BluetoothDevice^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothDevice^ UnwrapBluetoothDevice(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothClassOfDevice(::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ UnwrapBluetoothClassOfDevice(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAppearanceCategories(::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^ UnwrapBluetoothLEAppearanceCategories(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAppearanceSubcategories(::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^ UnwrapBluetoothLEAppearanceSubcategories(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEAppearance(::Windows::Devices::Bluetooth::BluetoothLEAppearance^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ UnwrapBluetoothLEAppearance(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothLEDevice(::Windows::Devices::Bluetooth::BluetoothLEDevice^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothLEDevice^ UnwrapBluetoothLEDevice(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapBluetoothSignalStrengthFilter(::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ wintRtInstance);
   ::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ UnwrapBluetoothSignalStrengthFilter(Local<Value> value);
-  
+
 
 
   static void InitBluetoothCacheModeEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothCacheMode").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("cached").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothCacheMode::Cached)));
@@ -108,7 +107,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothMajorClassEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothMajorClass").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("miscellaneous").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothMajorClass::Miscellaneous)));
@@ -127,7 +126,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothMinorClassEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothMinorClass").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("uncategorized").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothMinorClass::Uncategorized)));
@@ -207,7 +206,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothServiceCapabilitiesEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothServiceCapabilities").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("none").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothServiceCapabilities::None)));
@@ -226,7 +225,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothConnectionStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothConnectionStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("disconnected").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothConnectionStatus::Disconnected)));
@@ -237,7 +236,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothErrorEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothError").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("success").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothError::Success)));
@@ -256,7 +255,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
   static void InitBluetoothAddressTypeEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("BluetoothAddressType").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("public").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Bluetooth::BluetoothAddressType::Public)));
@@ -266,25 +265,25 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
 
 
-  
+
   class BluetoothAdapter : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothAdapter").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-                  
+
       Nan::SetPrototypeMethod(localRef, "getRadioAsync", GetRadioAsync);
-      
-                  
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bluetoothAddress").ToLocalChecked(), BluetoothAddressGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceId").ToLocalChecked(), DeviceIdGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isAdvertisementOffloadSupported").ToLocalChecked(), IsAdvertisementOffloadSupportedGetter);
@@ -292,7 +291,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isClassicSupported").ToLocalChecked(), IsClassicSupportedGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isLowEnergySupported").ToLocalChecked(), IsLowEnergySupportedGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isPeripheralRoleSupported").ToLocalChecked(), IsPeripheralRoleSupportedGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -312,13 +311,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothAdapter(::Windows::Devices::Bluetooth::BluetoothAdapter^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -357,14 +356,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothAdapter^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothAdapter^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -389,7 +388,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -432,7 +431,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Radios::Radio^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -446,17 +445,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::Radio^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::Radio^> t)
+      {
         try
         {
           auto result = t.get();
@@ -472,7 +471,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -487,16 +486,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
 
     static void FromIdAsync(Nan::NAN_METHOD_ARGS_TYPE info)
     {
@@ -509,7 +508,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothAdapter^>^ op;
-      
+
 
       if (info.Length() == 2
         && info[0]->IsString())
@@ -517,7 +516,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothAdapter::FromIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -526,24 +525,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothAdapter^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothAdapter^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -552,7 +551,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -567,13 +566,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetDefaultAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -587,7 +586,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothAdapter^>^ op;
-      
+
 
       if (info.Length() == 1)
       {
@@ -601,24 +600,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothAdapter^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothAdapter^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -627,7 +626,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -642,13 +641,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
 
@@ -671,7 +670,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -681,7 +680,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void BluetoothAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -689,7 +688,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->BluetoothAddress;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -701,11 +700,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceIdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -713,7 +712,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DeviceId;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -725,11 +724,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsAdvertisementOffloadSupportedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -737,7 +736,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsAdvertisementOffloadSupported;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -749,11 +748,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsCentralRoleSupportedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -761,7 +760,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsCentralRoleSupported;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -773,11 +772,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsClassicSupportedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -785,7 +784,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsClassicSupported;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -797,11 +796,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsLowEnergySupportedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -809,7 +808,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsLowEnergySupported;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -821,11 +820,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsPeripheralRoleSupportedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothAdapter^>(info.This()))
       {
         return;
@@ -833,7 +832,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothAdapter *wrapper = BluetoothAdapter::Unwrap<BluetoothAdapter>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsPeripheralRoleSupported;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -845,7 +844,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -884,21 +883,21 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothDeviceId : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothDeviceId").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("id").ToLocalChecked(), IdGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isClassicDevice").ToLocalChecked(), IsClassicDeviceGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isLowEnergyDevice").ToLocalChecked(), IsLowEnergyDeviceGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -913,13 +912,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothDeviceId(::Windows::Devices::Bluetooth::BluetoothDeviceId^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -958,14 +957,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothDeviceId^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDeviceId^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothDeviceId^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -990,7 +989,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1015,14 +1014,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void IdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDeviceId^>(info.This()))
       {
         return;
@@ -1030,7 +1029,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDeviceId *wrapper = BluetoothDeviceId::Unwrap<BluetoothDeviceId>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Id;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -1042,11 +1041,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsClassicDeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDeviceId^>(info.This()))
       {
         return;
@@ -1054,7 +1053,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDeviceId *wrapper = BluetoothDeviceId::Unwrap<BluetoothDeviceId>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsClassicDevice;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -1066,11 +1065,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void IsLowEnergyDeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDeviceId^>(info.This()))
       {
         return;
@@ -1078,7 +1077,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDeviceId *wrapper = BluetoothDeviceId::Unwrap<BluetoothDeviceId>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsLowEnergyDevice;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -1090,7 +1089,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -1129,17 +1128,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothUuidHelper : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothUuidHelper").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1156,13 +1155,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothUuidHelper(::Windows::Devices::Bluetooth::BluetoothUuidHelper^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1201,14 +1200,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothUuidHelper^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothUuidHelper^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothUuidHelper^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1233,7 +1232,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1258,7 +1257,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
     static void FromShortId(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -1271,7 +1270,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Guid result;
           result = ::Windows::Devices::Bluetooth::BluetoothUuidHelper::FromShortId(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::GuidToJs(result));
@@ -1283,7 +1282,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1299,7 +1298,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
-          
+
           ::Platform::IBox<unsigned int>^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothUuidHelper::TryGetShortId(arg0);
           info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Integer>(result->Value)) : Undefined());
@@ -1311,7 +1310,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1356,32 +1355,32 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothDevice : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothDevice").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-            
+
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "requestAccessAsync", RequestAccessAsync);
       Nan::SetPrototypeMethod(localRef, "getRfcommServicesAsync", GetRfcommServicesAsync);
       Nan::SetPrototypeMethod(localRef, "getRfcommServicesForIdAsync", GetRfcommServicesForIdAsync);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bluetoothAddress").ToLocalChecked(), BluetoothAddressGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("classOfDevice").ToLocalChecked(), ClassOfDeviceGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("connectionStatus").ToLocalChecked(), ConnectionStatusGetter);
@@ -1392,7 +1391,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("sdpRecords").ToLocalChecked(), SdpRecordsGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceInformation").ToLocalChecked(), DeviceInformationGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceAccessInformation").ToLocalChecked(), DeviceAccessInformationGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1419,13 +1418,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothDevice(::Windows::Devices::Bluetooth::BluetoothDevice^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1464,14 +1463,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothDevice^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothDevice^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1496,7 +1495,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1539,7 +1538,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceAccessStatus>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -1553,17 +1552,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceAccessStatus> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceAccessStatus> t)
+      {
         try
         {
           auto result = t.get();
@@ -1579,7 +1578,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -1594,13 +1593,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetRfcommServicesAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -1621,7 +1620,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -1641,7 +1640,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothCacheMode arg0 = static_cast<::Windows::Devices::Bluetooth::BluetoothCacheMode>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = wrapper->_instance->GetRfcommServicesAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -1650,17 +1649,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -1676,7 +1675,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -1691,13 +1690,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetRfcommServicesForIdAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -1718,7 +1717,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^>^ op;
-    
+
 
       if (info.Length() == 2
         && NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::Rfcomm::RfcommServiceId^>(info[0]))
@@ -1726,7 +1725,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::Rfcomm::RfcommServiceId^ arg0 = dynamic_cast<::Windows::Devices::Bluetooth::Rfcomm::RfcommServiceId^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           op = wrapper->_instance->GetRfcommServicesForIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -1743,7 +1742,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           ::Windows::Devices::Bluetooth::Rfcomm::RfcommServiceId^ arg0 = dynamic_cast<::Windows::Devices::Bluetooth::Rfcomm::RfcommServiceId^>(NodeRT::Utils::GetObjectInstance(info[0]));
           ::Windows::Devices::Bluetooth::BluetoothCacheMode arg1 = static_cast<::Windows::Devices::Bluetooth::BluetoothCacheMode>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           op = wrapper->_instance->GetRfcommServicesForIdAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -1752,17 +1751,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceServicesResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -1778,7 +1777,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -1793,16 +1792,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
     static void Close(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1828,7 +1827,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
 		return;
@@ -1847,7 +1846,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothDevice^>^ op;
-      
+
 
       if (info.Length() == 2
         && info[0]->IsString())
@@ -1855,7 +1854,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothDevice::FromIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -1864,24 +1863,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -1890,7 +1889,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -1905,13 +1904,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FromHostNameAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -1925,7 +1924,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothDevice^>^ op;
-      
+
 
       if (info.Length() == 2
         && NodeRT::Utils::IsWinRtWrapperOf<::Windows::Networking::HostName^>(info[0]))
@@ -1933,7 +1932,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Networking::HostName^ arg0 = dynamic_cast<::Windows::Networking::HostName^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothDevice::FromHostNameAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -1942,24 +1941,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -1968,7 +1967,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -1983,13 +1982,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FromBluetoothAddressAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2003,7 +2002,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothDevice^>^ op;
-      
+
 
       if (info.Length() == 2
         && info[0]->IsNumber())
@@ -2011,7 +2010,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothDevice::FromBluetoothAddressAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -2020,24 +2019,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothDevice^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -2046,7 +2045,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -2061,13 +2060,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
 
@@ -2081,7 +2080,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           bool arg0 = Nan::To<bool>(info[0]).FromMaybe(false);
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromPairingState(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2093,7 +2092,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2109,7 +2108,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothConnectionStatus arg0 = static_cast<::Windows::Devices::Bluetooth::BluetoothConnectionStatus>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromConnectionStatus(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2121,7 +2120,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2137,7 +2136,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromDeviceName(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2149,7 +2148,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2165,7 +2164,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromBluetoothAddress(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2177,7 +2176,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2193,7 +2192,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ arg0 = UnwrapBluetoothClassOfDevice(info[0]);
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromClassOfDevice(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2205,7 +2204,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2230,7 +2229,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2240,7 +2239,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void BluetoothAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2248,7 +2247,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->BluetoothAddress;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -2260,11 +2259,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ClassOfDeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2272,7 +2271,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ result = wrapper->_instance->ClassOfDevice;
         info.GetReturnValue().Set(WrapBluetoothClassOfDevice(result));
@@ -2284,11 +2283,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ConnectionStatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2296,7 +2295,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothConnectionStatus result = wrapper->_instance->ConnectionStatus;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -2308,11 +2307,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceIdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2320,7 +2319,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DeviceId;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2332,11 +2331,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void HostNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2344,7 +2343,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Networking::HostName^ result = wrapper->_instance->HostName;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Networking", "HostName", result));
@@ -2356,11 +2355,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2368,7 +2367,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -2380,11 +2379,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RfcommServicesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2392,10 +2391,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceService^>^ result = wrapper->_instance->RfcommServices;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceService^>::CreateVectorViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceService^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Bluetooth::Rfcomm::RfcommDeviceService^ val) -> Local<Value> {
               return NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Bluetooth.Rfcomm", "RfcommDeviceService", val);
             },
@@ -2414,11 +2413,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SdpRecordsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2426,10 +2425,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVectorView<::Windows::Storage::Streams::IBuffer^>^ result = wrapper->_instance->SdpRecords;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Storage::Streams::IBuffer^>::CreateVectorViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Storage::Streams::IBuffer^>::CreateVectorViewWrapper(result,
             [](::Windows::Storage::Streams::IBuffer^ val) -> Local<Value> {
               return NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IBuffer", val);
             },
@@ -2448,11 +2447,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2460,7 +2459,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->DeviceInformation;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Enumeration", "DeviceInformation", result));
@@ -2472,11 +2471,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceAccessInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothDevice^>(info.This()))
       {
         return;
@@ -2484,7 +2483,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceAccessInformation^ result = wrapper->_instance->DeviceAccessInformation;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Enumeration", "DeviceAccessInformation", result));
@@ -2496,7 +2495,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2511,9 +2510,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str))
       {
@@ -2523,12 +2522,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2580,12 +2579,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2637,12 +2636,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothDevice *wrapper = BluetoothDevice::Unwrap<BluetoothDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2686,7 +2685,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -2729,7 +2728,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -2743,12 +2742,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str))
         {
@@ -2824,22 +2823,22 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothClassOfDevice : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothClassOfDevice").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("majorClass").ToLocalChecked(), MajorClassGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("minorClass").ToLocalChecked(), MinorClassGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("rawValue").ToLocalChecked(), RawValueGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("serviceCapabilities").ToLocalChecked(), ServiceCapabilitiesGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2856,13 +2855,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothClassOfDevice(::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2901,14 +2900,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothClassOfDevice^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothClassOfDevice^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2933,7 +2932,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2958,7 +2957,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
     static void FromRawValue(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2971,7 +2970,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothClassOfDevice::FromRawValue(arg0);
           info.GetReturnValue().Set(WrapBluetoothClassOfDevice(result));
@@ -2983,7 +2982,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3003,7 +3002,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           ::Windows::Devices::Bluetooth::BluetoothMajorClass arg0 = static_cast<::Windows::Devices::Bluetooth::BluetoothMajorClass>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Bluetooth::BluetoothMinorClass arg1 = static_cast<::Windows::Devices::Bluetooth::BluetoothMinorClass>(Nan::To<int32_t>(info[1]).FromMaybe(0));
           ::Windows::Devices::Bluetooth::BluetoothServiceCapabilities arg2 = static_cast<::Windows::Devices::Bluetooth::BluetoothServiceCapabilities>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           ::Windows::Devices::Bluetooth::BluetoothClassOfDevice^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothClassOfDevice::FromParts(arg0, arg1, arg2);
           info.GetReturnValue().Set(WrapBluetoothClassOfDevice(result));
@@ -3015,7 +3014,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3025,7 +3024,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void MajorClassGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothClassOfDevice^>(info.This()))
       {
         return;
@@ -3033,7 +3032,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothClassOfDevice *wrapper = BluetoothClassOfDevice::Unwrap<BluetoothClassOfDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothMajorClass result = wrapper->_instance->MajorClass;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3045,11 +3044,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MinorClassGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothClassOfDevice^>(info.This()))
       {
         return;
@@ -3057,7 +3056,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothClassOfDevice *wrapper = BluetoothClassOfDevice::Unwrap<BluetoothClassOfDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothMinorClass result = wrapper->_instance->MinorClass;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3069,11 +3068,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RawValueGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothClassOfDevice^>(info.This()))
       {
         return;
@@ -3081,7 +3080,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothClassOfDevice *wrapper = BluetoothClassOfDevice::Unwrap<BluetoothClassOfDevice>(info.This());
 
-      try 
+      try
       {
         unsigned int result = wrapper->_instance->RawValue;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3093,11 +3092,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ServiceCapabilitiesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothClassOfDevice^>(info.This()))
       {
         return;
@@ -3105,7 +3104,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothClassOfDevice *wrapper = BluetoothClassOfDevice::Unwrap<BluetoothClassOfDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothServiceCapabilities result = wrapper->_instance->ServiceCapabilities;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3117,7 +3116,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -3156,17 +3155,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAppearanceCategories : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAppearanceCategories").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3203,13 +3202,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAppearanceCategories(::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3248,14 +3247,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3280,7 +3279,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3305,7 +3304,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
@@ -3314,7 +3313,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::BarcodeScanner;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3326,12 +3325,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void BloodPressureGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::BloodPressure;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3343,12 +3342,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ClockGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Clock;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3360,12 +3359,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ComputerGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Computer;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3377,12 +3376,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Cycling;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3394,12 +3393,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DisplayGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Display;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3411,12 +3410,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void EyeGlassesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::EyeGlasses;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3428,12 +3427,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void GlucoseMeterGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::GlucoseMeter;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3445,12 +3444,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void HeartRateGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::HeartRate;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3462,12 +3461,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void HumanInterfaceDeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::HumanInterfaceDevice;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3479,12 +3478,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void KeyringGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Keyring;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3496,12 +3495,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MediaPlayerGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::MediaPlayer;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3513,12 +3512,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OutdoorSportActivityGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::OutdoorSportActivity;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3530,12 +3529,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void PhoneGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Phone;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3547,12 +3546,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void PulseOximeterGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::PulseOximeter;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3564,12 +3563,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RemoteControlGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::RemoteControl;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3581,12 +3580,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RunningWalkingGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::RunningWalking;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3598,12 +3597,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void TagGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Tag;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3615,12 +3614,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ThermometerGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Thermometer;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3632,12 +3631,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void UncategorizedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Uncategorized;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3649,12 +3648,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void WatchGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::Watch;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3666,12 +3665,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void WeightScaleGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories::WeightScale;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3683,7 +3682,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
   private:
     ::Windows::Devices::Bluetooth::BluetoothLEAppearanceCategories^ _instance;
@@ -3721,17 +3720,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAppearanceSubcategories : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAppearanceSubcategories").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3774,13 +3773,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAppearanceSubcategories(::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3819,14 +3818,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3851,7 +3850,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3876,7 +3875,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
@@ -3885,7 +3884,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::BarcodeScanner;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3897,12 +3896,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void BloodPressureArmGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::BloodPressureArm;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3914,12 +3913,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void BloodPressureWristGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::BloodPressureWrist;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3931,12 +3930,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CardReaderGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CardReader;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3948,12 +3947,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingCadenceSensorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CyclingCadenceSensor;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3965,12 +3964,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingComputerGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CyclingComputer;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3982,12 +3981,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingPowerSensorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CyclingPowerSensor;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3999,12 +3998,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingSpeedCadenceSensorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CyclingSpeedCadenceSensor;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4016,12 +4015,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void CyclingSpeedSensorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::CyclingSpeedSensor;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4033,12 +4032,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DigitalPenGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::DigitalPen;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4050,12 +4049,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DigitizerTabletGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::DigitizerTablet;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4067,12 +4066,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void GamepadGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::Gamepad;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4084,12 +4083,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void GenericGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::Generic;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4101,12 +4100,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void HeartRateBeltGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::HeartRateBelt;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4118,12 +4117,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void JoystickGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::Joystick;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4135,12 +4134,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void KeyboardGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::Keyboard;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4152,12 +4151,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void LocationDisplayGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::LocationDisplay;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4169,12 +4168,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void LocationNavigationDisplayGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::LocationNavigationDisplay;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4186,12 +4185,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void LocationNavigationPodGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::LocationNavigationPod;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4203,12 +4202,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void LocationPodGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::LocationPod;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4220,12 +4219,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void MouseGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::Mouse;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4237,12 +4236,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OximeterFingertipGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::OximeterFingertip;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4254,12 +4253,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OximeterWristWornGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::OximeterWristWorn;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4271,12 +4270,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RunningWalkingInShoeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::RunningWalkingInShoe;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4288,12 +4287,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RunningWalkingOnHipGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::RunningWalkingOnHip;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4305,12 +4304,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RunningWalkingOnShoeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::RunningWalkingOnShoe;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4322,12 +4321,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SportsWatchGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::SportsWatch;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4339,12 +4338,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ThermometerEarGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
 
-      try 
+      try
       {
         unsigned short result = ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories::ThermometerEar;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4356,7 +4355,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
   private:
     ::Windows::Devices::Bluetooth::BluetoothLEAppearanceSubcategories^ _instance;
@@ -4394,21 +4393,21 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEAppearance : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEAppearance").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("category").ToLocalChecked(), CategoryGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("rawValue").ToLocalChecked(), RawValueGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("subCategory").ToLocalChecked(), SubCategoryGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4425,13 +4424,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEAppearance(::Windows::Devices::Bluetooth::BluetoothLEAppearance^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4470,14 +4469,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearance^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothLEAppearance^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4502,7 +4501,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4527,7 +4526,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
     static void FromRawValue(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -4540,7 +4539,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned short arg0 = static_cast<unsigned short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEAppearance::FromRawValue(arg0);
           info.GetReturnValue().Set(WrapBluetoothLEAppearance(result));
@@ -4552,7 +4551,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4570,7 +4569,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           unsigned short arg0 = static_cast<unsigned short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           unsigned short arg1 = static_cast<unsigned short>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEAppearance::FromParts(arg0, arg1);
           info.GetReturnValue().Set(WrapBluetoothLEAppearance(result));
@@ -4582,7 +4581,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4592,7 +4591,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void CategoryGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearance^>(info.This()))
       {
         return;
@@ -4600,7 +4599,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAppearance *wrapper = BluetoothLEAppearance::Unwrap<BluetoothLEAppearance>(info.This());
 
-      try 
+      try
       {
         unsigned short result = wrapper->_instance->Category;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4612,11 +4611,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void RawValueGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearance^>(info.This()))
       {
         return;
@@ -4624,7 +4623,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAppearance *wrapper = BluetoothLEAppearance::Unwrap<BluetoothLEAppearance>(info.This());
 
-      try 
+      try
       {
         unsigned short result = wrapper->_instance->RawValue;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4636,11 +4635,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SubCategoryGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEAppearance^>(info.This()))
       {
         return;
@@ -4648,7 +4647,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEAppearance *wrapper = BluetoothLEAppearance::Unwrap<BluetoothLEAppearance>(info.This());
 
-      try 
+      try
       {
         unsigned short result = wrapper->_instance->SubCategory;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -4660,7 +4659,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
   private:
@@ -4699,33 +4698,33 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothLEDevice : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothLEDevice").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-            
+
       Nan::SetPrototypeMethod(localRef, "getGattService", GetGattService);
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "requestAccessAsync", RequestAccessAsync);
       Nan::SetPrototypeMethod(localRef, "getGattServicesAsync", GetGattServicesAsync);
       Nan::SetPrototypeMethod(localRef, "getGattServicesForUuidAsync", GetGattServicesForUuidAsync);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bluetoothAddress").ToLocalChecked(), BluetoothAddressGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("connectionStatus").ToLocalChecked(), ConnectionStatusGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceId").ToLocalChecked(), DeviceIdGetter);
@@ -4735,7 +4734,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("bluetoothAddressType").ToLocalChecked(), BluetoothAddressTypeGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceInformation").ToLocalChecked(), DeviceInformationGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceAccessInformation").ToLocalChecked(), DeviceAccessInformationGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4760,13 +4759,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothLEDevice(::Windows::Devices::Bluetooth::BluetoothLEDevice^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4805,14 +4804,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothLEDevice^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothLEDevice^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4837,7 +4836,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4880,7 +4879,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceAccessStatus>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -4894,17 +4893,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceAccessStatus> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceAccessStatus> t)
+      {
         try
         {
           auto result = t.get();
@@ -4920,7 +4919,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -4935,13 +4934,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetGattServicesAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -4962,7 +4961,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -4982,7 +4981,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothCacheMode arg0 = static_cast<::Windows::Devices::Bluetooth::BluetoothCacheMode>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = wrapper->_instance->GetGattServicesAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -4991,17 +4990,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -5017,7 +5016,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5032,13 +5031,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetGattServicesForUuidAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -5059,7 +5058,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^>^ op;
-    
+
 
       if (info.Length() == 2
         && NodeRT::Utils::IsGuid(info[0]))
@@ -5067,7 +5066,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
-          
+
           op = wrapper->_instance->GetGattServicesForUuidAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5084,7 +5083,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
           ::Windows::Devices::Bluetooth::BluetoothCacheMode arg1 = static_cast<::Windows::Devices::Bluetooth::BluetoothCacheMode>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           op = wrapper->_instance->GetGattServicesForUuidAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -5093,17 +5092,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceServicesResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -5119,7 +5118,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5134,16 +5133,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
     static void GetGattService(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -5161,7 +5160,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
-          
+
           ::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService^ result;
           result = wrapper->_instance->GetGattService(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Bluetooth.GenericAttributeProfile", "GattDeviceService", result));
@@ -5173,7 +5172,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5204,7 +5203,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
 		return;
@@ -5223,7 +5222,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothLEDevice^>^ op;
-      
+
 
       if (info.Length() == 3
         && info[0]->IsNumber()
@@ -5233,7 +5232,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Bluetooth::BluetoothAddressType arg1 = static_cast<::Windows::Devices::Bluetooth::BluetoothAddressType>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothLEDevice::FromBluetoothAddressAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -5248,7 +5247,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothLEDevice::FromBluetoothAddressAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5257,24 +5256,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothLEDevice^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothLEDevice^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -5283,7 +5282,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5298,13 +5297,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FromIdAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -5318,7 +5317,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Bluetooth::BluetoothLEDevice^>^ op;
-      
+
 
       if (info.Length() == 2
         && info[0]->IsString())
@@ -5326,7 +5325,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Bluetooth::BluetoothLEDevice::FromIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5335,24 +5334,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothLEDevice^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Bluetooth::BluetoothLEDevice^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -5361,7 +5360,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5376,13 +5375,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
 
@@ -5396,7 +5395,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           bool arg0 = Nan::To<bool>(info[0]).FromMaybe(false);
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromPairingState(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5408,7 +5407,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5424,7 +5423,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothConnectionStatus arg0 = static_cast<::Windows::Devices::Bluetooth::BluetoothConnectionStatus>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromConnectionStatus(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5436,7 +5435,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5452,7 +5451,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromDeviceName(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5464,7 +5463,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5480,7 +5479,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromBluetoothAddress(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5500,7 +5499,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Bluetooth::BluetoothAddressType arg1 = static_cast<::Windows::Devices::Bluetooth::BluetoothAddressType>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromBluetoothAddress(arg0, arg1);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5512,7 +5511,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5528,7 +5527,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         try
         {
           ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ arg0 = UnwrapBluetoothLEAppearance(info[0]);
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromAppearance(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5540,7 +5539,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5565,7 +5564,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5575,7 +5574,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     static void BluetoothAddressGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5583,7 +5582,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->BluetoothAddress;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -5595,11 +5594,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void ConnectionStatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5607,7 +5606,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothConnectionStatus result = wrapper->_instance->ConnectionStatus;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -5619,11 +5618,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceIdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5631,7 +5630,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DeviceId;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5643,11 +5642,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void GattServicesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5655,10 +5654,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService^>^ result = wrapper->_instance->GattServices;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService^>::CreateVectorViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService^ val) -> Local<Value> {
               return NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Bluetooth.GenericAttributeProfile", "GattDeviceService", val);
             },
@@ -5677,11 +5676,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5689,7 +5688,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5701,11 +5700,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void AppearanceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5713,7 +5712,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothLEAppearance^ result = wrapper->_instance->Appearance;
         info.GetReturnValue().Set(WrapBluetoothLEAppearance(result));
@@ -5725,11 +5724,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void BluetoothAddressTypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5737,7 +5736,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Bluetooth::BluetoothAddressType result = wrapper->_instance->BluetoothAddressType;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -5749,11 +5748,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5761,7 +5760,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->DeviceInformation;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Enumeration", "DeviceInformation", result));
@@ -5773,11 +5772,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void DeviceAccessInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothLEDevice^>(info.This()))
       {
         return;
@@ -5785,7 +5784,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceAccessInformation^ result = wrapper->_instance->DeviceAccessInformation;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Devices.Enumeration", "DeviceAccessInformation", result));
@@ -5797,7 +5796,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -5812,9 +5811,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str))
       {
@@ -5824,12 +5823,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -5881,12 +5880,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -5938,12 +5937,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		  return;
         }
         BluetoothLEDevice *wrapper = BluetoothLEDevice::Unwrap<BluetoothLEDevice>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -5987,7 +5986,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -6030,7 +6029,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -6044,12 +6043,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str))
         {
@@ -6125,22 +6124,22 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
   class BluetoothSignalStrengthFilter : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("BluetoothSignalStrengthFilter").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("samplingInterval").ToLocalChecked(), SamplingIntervalGetter, SamplingIntervalSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("outOfRangeTimeout").ToLocalChecked(), OutOfRangeTimeoutGetter, OutOfRangeTimeoutSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("outOfRangeThresholdInDBm").ToLocalChecked(), OutOfRangeThresholdInDBmGetter, OutOfRangeThresholdInDBmSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("inRangeThresholdInDBm").ToLocalChecked(), InRangeThresholdInDBmGetter, InRangeThresholdInDBmSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6155,13 +6154,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
   private:
-    
+
     BluetoothSignalStrengthFilter(::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6200,14 +6199,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
           return;
         }
       }
-      
+
       ::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6244,7 +6243,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6269,14 +6268,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     }
 
 
-  
+
 
 
 
     static void SamplingIntervalGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(info.This()))
       {
         return;
@@ -6284,7 +6283,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
         ::Platform::IBox<::Windows::Foundation::TimeSpan>^ result = wrapper->_instance->SamplingInterval;
         info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Number>(result->Value.Duration/10000.0)) : Undefined());
@@ -6296,11 +6295,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void SamplingIntervalSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsNumber())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -6314,9 +6313,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Platform::IBox<::Windows::Foundation::TimeSpan>^ winRtValue = ref new ::Platform::Box<::Windows::Foundation::TimeSpan>(NodeRT::Utils::TimeSpanFromMilli(Nan::To<int64_t>(value).FromMaybe(0)));
 
         wrapper->_instance->SamplingInterval = winRtValue;
@@ -6326,11 +6325,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void OutOfRangeTimeoutGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(info.This()))
       {
         return;
@@ -6338,7 +6337,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
         ::Platform::IBox<::Windows::Foundation::TimeSpan>^ result = wrapper->_instance->OutOfRangeTimeout;
         info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Number>(result->Value.Duration/10000.0)) : Undefined());
@@ -6350,11 +6349,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OutOfRangeTimeoutSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsNumber())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -6368,9 +6367,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Platform::IBox<::Windows::Foundation::TimeSpan>^ winRtValue = ref new ::Platform::Box<::Windows::Foundation::TimeSpan>(NodeRT::Utils::TimeSpanFromMilli(Nan::To<int64_t>(value).FromMaybe(0)));
 
         wrapper->_instance->OutOfRangeTimeout = winRtValue;
@@ -6380,11 +6379,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void OutOfRangeThresholdInDBmGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(info.This()))
       {
         return;
@@ -6392,7 +6391,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
         ::Platform::IBox<short>^ result = wrapper->_instance->OutOfRangeThresholdInDBm;
         info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Integer>(result->Value)) : Undefined());
@@ -6404,11 +6403,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void OutOfRangeThresholdInDBmSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -6422,9 +6421,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Platform::IBox<short>^ winRtValue = ref new ::Platform::Box<short>(static_cast<short>(Nan::To<int32_t>(value).FromMaybe(0)));
 
         wrapper->_instance->OutOfRangeThresholdInDBm = winRtValue;
@@ -6434,11 +6433,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void InRangeThresholdInDBmGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Bluetooth::BluetoothSignalStrengthFilter^>(info.This()))
       {
         return;
@@ -6446,7 +6445,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
         ::Platform::IBox<short>^ result = wrapper->_instance->InRangeThresholdInDBm;
         info.GetReturnValue().Set(result ? static_cast<Local<Value>>(Nan::New<Integer>(result->Value)) : Undefined());
@@ -6458,11 +6457,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
     }
-    
+
     static void InRangeThresholdInDBmSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsInt32())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -6476,9 +6475,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 
       BluetoothSignalStrengthFilter *wrapper = BluetoothSignalStrengthFilter::Unwrap<BluetoothSignalStrengthFilter>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Platform::IBox<short>^ winRtValue = ref new ::Platform::Box<short>(static_cast<short>(Nan::To<int32_t>(value).FromMaybe(0)));
 
         wrapper->_instance->InRangeThresholdInDBm = winRtValue;
@@ -6488,7 +6487,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -6525,7 +6524,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
     BluetoothSignalStrengthFilter::Init(exports);
   }
 
-} } } } 
+} } } }
 
 NAN_MODULE_INIT(init)
 {

--- a/uwp/windows.devices.bluetooth/node-async.h
+++ b/uwp/windows.devices.bluetooth/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.devices.bluetooth/node-async.h
+++ b/uwp/windows.devices.bluetooth/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.devices.enumeration/CollectionsWrap.h
+++ b/uwp/windows.devices.enumeration/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.devices.enumeration/NodeRtUtils.cpp
+++ b/uwp/windows.devices.enumeration/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.devices.enumeration/NodeRtUtils.cpp
+++ b/uwp/windows.devices.enumeration/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.devices.enumeration/OpaqueWrapper.h
+++ b/uwp/windows.devices.enumeration/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.devices.enumeration/_nodert_generated.cpp
+++ b/uwp/windows.devices.enumeration/_nodert_generated.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -59,80 +58,80 @@ using Nan::HandleScope;
 using Nan::TryCatch;
 using namespace concurrency;
 
-namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration { 
+namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration {
 
   v8::Local<v8::Value> WrapDeviceConnectionChangeTriggerDetails(::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^ UnwrapDeviceConnectionChangeTriggerDetails(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDevicePickerAppearance(::Windows::Devices::Enumeration::DevicePickerAppearance^ wintRtInstance);
   ::Windows::Devices::Enumeration::DevicePickerAppearance^ UnwrapDevicePickerAppearance(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceSelectedEventArgs(::Windows::Devices::Enumeration::DeviceSelectedEventArgs^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceSelectedEventArgs^ UnwrapDeviceSelectedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceDisconnectButtonClickedEventArgs(::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^ UnwrapDeviceDisconnectButtonClickedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDevicePickerFilter(::Windows::Devices::Enumeration::DevicePickerFilter^ wintRtInstance);
   ::Windows::Devices::Enumeration::DevicePickerFilter^ UnwrapDevicePickerFilter(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDevicePicker(::Windows::Devices::Enumeration::DevicePicker^ wintRtInstance);
   ::Windows::Devices::Enumeration::DevicePicker^ UnwrapDevicePicker(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceThumbnail(::Windows::Devices::Enumeration::DeviceThumbnail^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceThumbnail^ UnwrapDeviceThumbnail(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapEnclosureLocation(::Windows::Devices::Enumeration::EnclosureLocation^ wintRtInstance);
   ::Windows::Devices::Enumeration::EnclosureLocation^ UnwrapEnclosureLocation(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceInformationUpdate(::Windows::Devices::Enumeration::DeviceInformationUpdate^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceInformationUpdate^ UnwrapDeviceInformationUpdate(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceInformationCollection(::Windows::Devices::Enumeration::DeviceInformationCollection^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceInformationCollection^ UnwrapDeviceInformationCollection(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceWatcher(::Windows::Devices::Enumeration::DeviceWatcher^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceWatcher^ UnwrapDeviceWatcher(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceInformation(::Windows::Devices::Enumeration::DeviceInformation^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceInformation^ UnwrapDeviceInformation(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDevicePairingResult(::Windows::Devices::Enumeration::DevicePairingResult^ wintRtInstance);
   ::Windows::Devices::Enumeration::DevicePairingResult^ UnwrapDevicePairingResult(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceUnpairingResult(::Windows::Devices::Enumeration::DeviceUnpairingResult^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceUnpairingResult^ UnwrapDeviceUnpairingResult(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIDevicePairingSettings(::Windows::Devices::Enumeration::IDevicePairingSettings^ wintRtInstance);
   ::Windows::Devices::Enumeration::IDevicePairingSettings^ UnwrapIDevicePairingSettings(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDevicePairingRequestedEventArgs(::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^ wintRtInstance);
   ::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^ UnwrapDevicePairingRequestedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceInformationCustomPairing(::Windows::Devices::Enumeration::DeviceInformationCustomPairing^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceInformationCustomPairing^ UnwrapDeviceInformationCustomPairing(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceInformationPairing(::Windows::Devices::Enumeration::DeviceInformationPairing^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceInformationPairing^ UnwrapDeviceInformationPairing(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceAccessChangedEventArgs(::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^ UnwrapDeviceAccessChangedEventArgs(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceAccessInformation(::Windows::Devices::Enumeration::DeviceAccessInformation^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceAccessInformation^ UnwrapDeviceAccessInformation(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceWatcherEvent(::Windows::Devices::Enumeration::DeviceWatcherEvent^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceWatcherEvent^ UnwrapDeviceWatcherEvent(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeviceWatcherTriggerDetails(::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^ wintRtInstance);
   ::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^ UnwrapDeviceWatcherTriggerDetails(Local<Value> value);
-  
+
 
 
   static void InitDevicePickerDisplayStatusOptionsEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DevicePickerDisplayStatusOptions").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("none").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DevicePickerDisplayStatusOptions::None)));
@@ -145,7 +144,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceClassEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceClass").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("all").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceClass::All)));
@@ -161,7 +160,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceWatcherStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceWatcherStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("created").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceWatcherStatus::Created)));
@@ -176,7 +175,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitPanelEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("Panel").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unknown").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::Panel::Unknown)));
@@ -192,7 +191,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceInformationKindEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceInformationKind").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unknown").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceInformationKind::Unknown)));
@@ -209,7 +208,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceWatcherEventKindEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceWatcherEventKind").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("add").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceWatcherEventKind::Add)));
@@ -221,7 +220,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDevicePairingKindsEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DevicePairingKinds").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("none").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DevicePairingKinds::None)));
@@ -235,7 +234,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDevicePairingResultStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DevicePairingResultStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("paired").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DevicePairingResultStatus::Paired)));
@@ -264,7 +263,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceUnpairingResultStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceUnpairingResultStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unpaired").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceUnpairingResultStatus::Unpaired)));
@@ -278,7 +277,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDevicePairingProtectionLevelEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DevicePairingProtectionLevel").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("default").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DevicePairingProtectionLevel::Default)));
@@ -291,7 +290,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   static void InitDeviceAccessStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("DeviceAccessStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unspecified").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Enumeration::DeviceAccessStatus::Unspecified)));
@@ -302,7 +301,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
 
 
-  
+
   static bool IsColorJsObject(Local<Value> value)
   {
     if (!value->IsObject())
@@ -320,7 +319,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   {
     HandleScope scope;
     ::Windows::UI::Color returnValue;
-    
+
     if (!value->IsObject())
     {
       Nan::ThrowError(Nan::TypeError(NodeRT::Utils::NewString(L"Unexpected type, expected an object")));
@@ -339,11 +338,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
     Local<Object> obj = Nan::New<Object>();
 
-    
+
     return scope.Escape(obj);
   }
 
-  
+
   static bool IsRectJsObject(Local<Value> value)
   {
     if (!value->IsObject())
@@ -361,7 +360,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
   {
     HandleScope scope;
     ::Windows::Foundation::Rect returnValue;
-    
+
     if (!value->IsObject())
     {
       Nan::ThrowError(Nan::TypeError(NodeRT::Utils::NewString(L"Unexpected type, expected an object")));
@@ -380,26 +379,26 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
     Local<Object> obj = Nan::New<Object>();
 
-    
+
     return scope.Escape(obj);
   }
 
-  
+
   class DeviceConnectionChangeTriggerDetails : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceConnectionChangeTriggerDetails").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceId").ToLocalChecked(), DeviceIdGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -414,13 +413,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceConnectionChangeTriggerDetails(::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -459,14 +458,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -491,7 +490,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -516,14 +515,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void DeviceIdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceConnectionChangeTriggerDetails^>(info.This()))
       {
         return;
@@ -531,7 +530,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceConnectionChangeTriggerDetails *wrapper = DeviceConnectionChangeTriggerDetails::Unwrap<DeviceConnectionChangeTriggerDetails>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DeviceId;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -543,7 +542,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -582,17 +581,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DevicePickerAppearance : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DevicePickerAppearance").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("title").ToLocalChecked(), TitleGetter, TitleSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("selectedForegroundColor").ToLocalChecked(), SelectedForegroundColorGetter, SelectedForegroundColorSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("selectedBackgroundColor").ToLocalChecked(), SelectedBackgroundColorGetter, SelectedBackgroundColorSetter);
@@ -600,7 +599,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("foregroundColor").ToLocalChecked(), ForegroundColorGetter, ForegroundColorSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("backgroundColor").ToLocalChecked(), BackgroundColorGetter, BackgroundColorSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("accentColor").ToLocalChecked(), AccentColorGetter, AccentColorSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -615,13 +614,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DevicePickerAppearance(::Windows::Devices::Enumeration::DevicePickerAppearance^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -660,14 +659,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DevicePickerAppearance^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DevicePickerAppearance^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -692,7 +691,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -717,14 +716,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void TitleGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -732,7 +731,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Title;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -744,11 +743,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void TitleSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsString())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -762,9 +761,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
 
         wrapper->_instance->Title = winRtValue;
@@ -774,11 +773,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void SelectedForegroundColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -786,7 +785,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->SelectedForegroundColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -798,11 +797,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SelectedForegroundColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -816,9 +815,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->SelectedForegroundColor = winRtValue;
@@ -828,11 +827,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void SelectedBackgroundColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -840,7 +839,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->SelectedBackgroundColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -852,11 +851,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SelectedBackgroundColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -870,9 +869,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->SelectedBackgroundColor = winRtValue;
@@ -882,11 +881,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void SelectedAccentColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -894,7 +893,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->SelectedAccentColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -906,11 +905,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SelectedAccentColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -924,9 +923,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->SelectedAccentColor = winRtValue;
@@ -936,11 +935,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void ForegroundColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -948,7 +947,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->ForegroundColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -960,11 +959,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void ForegroundColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -978,9 +977,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->ForegroundColor = winRtValue;
@@ -990,11 +989,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void BackgroundColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -1002,7 +1001,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->BackgroundColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -1014,11 +1013,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void BackgroundColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1032,9 +1031,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->BackgroundColor = winRtValue;
@@ -1044,11 +1043,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void AccentColorGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerAppearance^>(info.This()))
       {
         return;
@@ -1056,7 +1055,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
         ::Windows::UI::Color result = wrapper->_instance->AccentColor;
         info.GetReturnValue().Set(NodeRT::Utils::ColorToJs(result));
@@ -1068,11 +1067,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void AccentColorSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsColor(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -1086,9 +1085,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerAppearance *wrapper = DevicePickerAppearance::Unwrap<DevicePickerAppearance>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::UI::Color winRtValue = NodeRT::Utils::ColorFromJs(value);
 
         wrapper->_instance->AccentColor = winRtValue;
@@ -1098,7 +1097,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -1137,19 +1136,19 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceSelectedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceSelectedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("selectedDevice").ToLocalChecked(), SelectedDeviceGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1164,13 +1163,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceSelectedEventArgs(::Windows::Devices::Enumeration::DeviceSelectedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1209,14 +1208,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceSelectedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceSelectedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceSelectedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1241,7 +1240,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1266,14 +1265,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void SelectedDeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceSelectedEventArgs^>(info.This()))
       {
         return;
@@ -1281,7 +1280,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceSelectedEventArgs *wrapper = DeviceSelectedEventArgs::Unwrap<DeviceSelectedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->SelectedDevice;
         info.GetReturnValue().Set(WrapDeviceInformation(result));
@@ -1293,7 +1292,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -1332,19 +1331,19 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceDisconnectButtonClickedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceDisconnectButtonClickedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("device").ToLocalChecked(), DeviceGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1359,13 +1358,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceDisconnectButtonClickedEventArgs(::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1404,14 +1403,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1436,7 +1435,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1461,14 +1460,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void DeviceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceDisconnectButtonClickedEventArgs^>(info.This()))
       {
         return;
@@ -1476,7 +1475,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceDisconnectButtonClickedEventArgs *wrapper = DeviceDisconnectButtonClickedEventArgs::Unwrap<DeviceDisconnectButtonClickedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->Device;
         info.GetReturnValue().Set(WrapDeviceInformation(result));
@@ -1488,7 +1487,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -1527,20 +1526,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DevicePickerFilter : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DevicePickerFilter").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("supportedDeviceClasses").ToLocalChecked(), SupportedDeviceClassesGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("supportedDeviceSelectors").ToLocalChecked(), SupportedDeviceSelectorsGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1555,13 +1554,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DevicePickerFilter(::Windows::Devices::Enumeration::DevicePickerFilter^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1600,14 +1599,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DevicePickerFilter^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerFilter^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DevicePickerFilter^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1632,7 +1631,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1657,14 +1656,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void SupportedDeviceClassesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerFilter^>(info.This()))
       {
         return;
@@ -1672,10 +1671,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerFilter *wrapper = DevicePickerFilter::Unwrap<DevicePickerFilter>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Windows::Devices::Enumeration::DeviceClass>^ result = wrapper->_instance->SupportedDeviceClasses;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Enumeration::DeviceClass>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Windows::Devices::Enumeration::DeviceClass>::CreateVectorWrapper(result,
             [](::Windows::Devices::Enumeration::DeviceClass val) -> Local<Value> {
               return Nan::New<Integer>(static_cast<int>(val));
             },
@@ -1694,11 +1693,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SupportedDeviceSelectorsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePickerFilter^>(info.This()))
       {
         return;
@@ -1706,10 +1705,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePickerFilter *wrapper = DevicePickerFilter::Unwrap<DevicePickerFilter>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Platform::String^>^ result = wrapper->_instance->SupportedDeviceSelectors;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::String^>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::String^>::CreateVectorWrapper(result,
             [](::Platform::String^ val) -> Local<Value> {
               return NodeRT::Utils::NewString(val->Data());
             },
@@ -1728,7 +1727,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -1767,36 +1766,36 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DevicePicker : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DevicePicker").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-            
+
       Nan::SetPrototypeMethod(localRef, "show", Show);
       Nan::SetPrototypeMethod(localRef, "hide", Hide);
       Nan::SetPrototypeMethod(localRef, "setDisplayStatus", SetDisplayStatus);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "pickSingleDeviceAsync", PickSingleDeviceAsync);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("appearance").ToLocalChecked(), AppearanceGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("filter").ToLocalChecked(), FilterGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("requestedProperties").ToLocalChecked(), RequestedPropertiesGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1811,13 +1810,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DevicePicker(::Windows::Devices::Enumeration::DevicePicker^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1856,14 +1855,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DevicePicker^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePicker^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DevicePicker^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1900,7 +1899,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -1943,7 +1942,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceInformation^>^ op;
-    
+
 
       if (info.Length() == 2
         && NodeRT::Utils::IsRect(info[0]))
@@ -1951,7 +1950,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Foundation::Rect arg0 = NodeRT::Utils::RectFromJs(info[0]);
-          
+
           op = wrapper->_instance->PickSingleDeviceAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -1968,7 +1967,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Foundation::Rect arg0 = NodeRT::Utils::RectFromJs(info[0]);
           ::Windows::UI::Popups::Placement arg1 = static_cast<::Windows::UI::Popups::Placement>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           op = wrapper->_instance->PickSingleDeviceAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -1977,17 +1976,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformation^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformation^> t)
+      {
         try
         {
           auto result = t.get();
@@ -2003,7 +2002,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -2018,16 +2017,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
     static void Show(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2045,9 +2044,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Foundation::Rect arg0 = NodeRT::Utils::RectFromJs(info[0]);
-          
+
           wrapper->_instance->Show(arg0);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2063,9 +2062,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Foundation::Rect arg0 = NodeRT::Utils::RectFromJs(info[0]);
           ::Windows::UI::Popups::Placement arg1 = static_cast<::Windows::UI::Popups::Placement>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           wrapper->_instance->Show(arg0, arg1);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2073,7 +2072,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2095,7 +2094,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           wrapper->_instance->Hide();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2103,7 +2102,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2130,9 +2129,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           ::Windows::Devices::Enumeration::DeviceInformation^ arg0 = UnwrapDeviceInformation(info[0]);
           Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[1])));
           ::Windows::Devices::Enumeration::DevicePickerDisplayStatusOptions arg2 = static_cast<::Windows::Devices::Enumeration::DevicePickerDisplayStatusOptions>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           wrapper->_instance->SetDisplayStatus(arg0, arg1, arg2);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2140,7 +2139,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2152,7 +2151,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void AppearanceGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePicker^>(info.This()))
       {
         return;
@@ -2160,7 +2159,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePickerAppearance^ result = wrapper->_instance->Appearance;
         info.GetReturnValue().Set(WrapDevicePickerAppearance(result));
@@ -2172,11 +2171,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void FilterGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePicker^>(info.This()))
       {
         return;
@@ -2184,7 +2183,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePickerFilter^ result = wrapper->_instance->Filter;
         info.GetReturnValue().Set(WrapDevicePickerFilter(result));
@@ -2196,11 +2195,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void RequestedPropertiesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePicker^>(info.This()))
       {
         return;
@@ -2208,10 +2207,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVector<::Platform::String^>^ result = wrapper->_instance->RequestedProperties;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::String^>::CreateVectorWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorWrapper<::Platform::String^>::CreateVectorWrapper(result,
             [](::Platform::String^ val) -> Local<Value> {
               return NodeRT::Utils::NewString(val->Data());
             },
@@ -2230,7 +2229,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2245,9 +2244,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"devicePickerDismissed", str))
       {
@@ -2257,12 +2256,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2314,12 +2313,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2371,12 +2370,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DevicePicker *wrapper = DevicePicker::Unwrap<DevicePicker>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -2420,7 +2419,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -2463,7 +2462,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -2477,12 +2476,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"devicePickerDismissed", str))
         {
@@ -2558,37 +2557,37 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceThumbnail : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceThumbnail").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-            
+
       Nan::SetPrototypeMethod(localRef, "getInputStreamAt", GetInputStreamAt);
       Nan::SetPrototypeMethod(localRef, "getOutputStreamAt", GetOutputStreamAt);
       Nan::SetPrototypeMethod(localRef, "seek", Seek);
       Nan::SetPrototypeMethod(localRef, "cloneStream", CloneStream);
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "readAsync", ReadAsync);
       Nan::SetPrototypeMethod(localRef, "writeAsync", WriteAsync);
       Nan::SetPrototypeMethod(localRef, "flushAsync", FlushAsync);
-      
-                  
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("contentType").ToLocalChecked(), ContentTypeGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("size").ToLocalChecked(), SizeGetter, SizeSetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("canRead").ToLocalChecked(), CanReadGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("canWrite").ToLocalChecked(), CanWriteGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("position").ToLocalChecked(), PositionGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2603,13 +2602,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceThumbnail(::Windows::Devices::Enumeration::DeviceThumbnail^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2648,14 +2647,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceThumbnail^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceThumbnail^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2680,7 +2679,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2723,7 +2722,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
       ::Windows::Foundation::IAsyncOperationWithProgress<::Windows::Storage::Streams::IBuffer^, unsigned int>^ op;
-    
+
 
       if (info.Length() == 4
         && NodeRT::Utils::IsWinRtWrapperOf<::Windows::Storage::Streams::IBuffer^>(info[0])
@@ -2735,7 +2734,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           ::Windows::Storage::Streams::IBuffer^ arg0 = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(info[0]));
           unsigned int arg1 = static_cast<unsigned int>(Nan::To<uint32_t>(info[1]).FromMaybe(0));
           ::Windows::Storage::Streams::InputStreamOptions arg2 = static_cast<::Windows::Storage::Streams::InputStreamOptions>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           op = wrapper->_instance->ReadAsync(arg0,arg1,arg2);
         }
         catch (Platform::Exception ^exception)
@@ -2744,17 +2743,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Storage::Streams::IBuffer^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Storage::Streams::IBuffer^> t)
+      {
         try
         {
           auto result = t.get();
@@ -2770,7 +2769,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -2785,13 +2784,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void WriteAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2812,7 +2811,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
       ::Windows::Foundation::IAsyncOperationWithProgress<unsigned int, unsigned int>^ op;
-    
+
 
       if (info.Length() == 2
         && NodeRT::Utils::IsWinRtWrapperOf<::Windows::Storage::Streams::IBuffer^>(info[0]))
@@ -2820,7 +2819,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Storage::Streams::IBuffer^ arg0 = dynamic_cast<::Windows::Storage::Streams::IBuffer^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           op = wrapper->_instance->WriteAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -2829,17 +2828,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<unsigned int> t) 
-      {	
+      opTask.then( [asyncToken] (task<unsigned int> t)
+      {
         try
         {
           auto result = t.get();
@@ -2855,7 +2854,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -2870,13 +2869,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FlushAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -2897,7 +2896,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<bool>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -2911,17 +2910,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<bool> t) 
-      {	
+      opTask.then( [asyncToken] (task<bool> t)
+      {
         try
         {
           auto result = t.get();
@@ -2937,7 +2936,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -2952,16 +2951,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
     static void GetInputStreamAt(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2979,7 +2978,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Storage::Streams::IInputStream^ result;
           result = wrapper->_instance->GetInputStreamAt(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IInputStream", result));
@@ -2991,7 +2990,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3014,7 +3013,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Storage::Streams::IOutputStream^ result;
           result = wrapper->_instance->GetOutputStreamAt(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Storage.Streams", "IOutputStream", result));
@@ -3026,7 +3025,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3049,9 +3048,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           wrapper->_instance->Seek(arg0);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -3059,7 +3058,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3091,7 +3090,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3122,7 +3121,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
 		return;
@@ -3135,7 +3134,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void ContentTypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info.This()))
       {
         return;
@@ -3143,7 +3142,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->ContentType;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -3155,11 +3154,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SizeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info.This()))
       {
         return;
@@ -3167,7 +3166,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->Size;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -3179,11 +3178,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void SizeSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!value->IsNumber())
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -3197,9 +3196,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
-        
+
         unsigned __int64 winRtValue = static_cast<unsigned __int64>(Nan::To<int64_t>(value).FromMaybe(0));
 
         wrapper->_instance->Size = winRtValue;
@@ -3209,11 +3208,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
     static void CanReadGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info.This()))
       {
         return;
@@ -3221,7 +3220,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->CanRead;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -3233,11 +3232,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void CanWriteGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info.This()))
       {
         return;
@@ -3245,7 +3244,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->CanWrite;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -3257,11 +3256,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PositionGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceThumbnail^>(info.This()))
       {
         return;
@@ -3269,7 +3268,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceThumbnail *wrapper = DeviceThumbnail::Unwrap<DeviceThumbnail>(info.This());
 
-      try 
+      try
       {
         unsigned __int64 result = wrapper->_instance->Position;
         info.GetReturnValue().Set(Nan::New<Number>(static_cast<double>(result)));
@@ -3281,7 +3280,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -3320,22 +3319,22 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class EnclosureLocation : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("EnclosureLocation").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("inDock").ToLocalChecked(), InDockGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("inLid").ToLocalChecked(), InLidGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("panel").ToLocalChecked(), PanelGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("rotationAngleInDegreesClockwise").ToLocalChecked(), RotationAngleInDegreesClockwiseGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3350,13 +3349,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     EnclosureLocation(::Windows::Devices::Enumeration::EnclosureLocation^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3395,14 +3394,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::EnclosureLocation^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::EnclosureLocation^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::EnclosureLocation^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3427,7 +3426,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3452,14 +3451,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void InDockGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::EnclosureLocation^>(info.This()))
       {
         return;
@@ -3467,7 +3466,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       EnclosureLocation *wrapper = EnclosureLocation::Unwrap<EnclosureLocation>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->InDock;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -3479,11 +3478,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void InLidGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::EnclosureLocation^>(info.This()))
       {
         return;
@@ -3491,7 +3490,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       EnclosureLocation *wrapper = EnclosureLocation::Unwrap<EnclosureLocation>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->InLid;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -3503,11 +3502,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PanelGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::EnclosureLocation^>(info.This()))
       {
         return;
@@ -3515,7 +3514,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       EnclosureLocation *wrapper = EnclosureLocation::Unwrap<EnclosureLocation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::Panel result = wrapper->_instance->Panel;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3527,11 +3526,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void RotationAngleInDegreesClockwiseGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::EnclosureLocation^>(info.This()))
       {
         return;
@@ -3539,7 +3538,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       EnclosureLocation *wrapper = EnclosureLocation::Unwrap<EnclosureLocation>(info.This());
 
-      try 
+      try
       {
         unsigned int result = wrapper->_instance->RotationAngleInDegreesClockwise;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3551,7 +3550,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -3590,21 +3589,21 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceInformationUpdate : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceInformationUpdate").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("id").ToLocalChecked(), IdGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("properties").ToLocalChecked(), PropertiesGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("kind").ToLocalChecked(), KindGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3619,13 +3618,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceInformationUpdate(::Windows::Devices::Enumeration::DeviceInformationUpdate^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3664,14 +3663,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceInformationUpdate^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationUpdate^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceInformationUpdate^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3696,7 +3695,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3721,14 +3720,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void IdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationUpdate^>(info.This()))
       {
         return;
@@ -3736,7 +3735,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationUpdate *wrapper = DeviceInformationUpdate::Unwrap<DeviceInformationUpdate>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Id;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -3748,11 +3747,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PropertiesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationUpdate^>(info.This()))
       {
         return;
@@ -3760,10 +3759,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationUpdate *wrapper = DeviceInformationUpdate::Unwrap<DeviceInformationUpdate>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IMapView<::Platform::String^, ::Platform::Object^>^ result = wrapper->_instance->Properties;
-        info.GetReturnValue().Set(NodeRT::Collections::MapViewWrapper<::Platform::String^,::Platform::Object^>::CreateMapViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::MapViewWrapper<::Platform::String^,::Platform::Object^>::CreateMapViewWrapper(result,
             [](::Platform::String^ val) -> Local<Value> {
               return NodeRT::Utils::NewString(val->Data());
             },
@@ -3785,11 +3784,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void KindGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationUpdate^>(info.This()))
       {
         return;
@@ -3797,7 +3796,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationUpdate *wrapper = DeviceInformationUpdate::Unwrap<DeviceInformationUpdate>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformationKind result = wrapper->_instance->Kind;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -3809,7 +3808,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -3848,23 +3847,23 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceInformationCollection : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceInformationCollection").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getAt", GetAt);
       Nan::SetPrototypeMethod(localRef, "indexOf", IndexOf);
       Nan::SetPrototypeMethod(localRef, "getMany", GetMany);
       Nan::SetPrototypeMethod(localRef, "first", First);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3879,13 +3878,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceInformationCollection(::Windows::Devices::Enumeration::DeviceInformationCollection^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3924,14 +3923,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceInformationCollection^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationCollection^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceInformationCollection^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3956,7 +3955,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3981,7 +3980,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
     static void GetAt(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3999,7 +3998,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Devices::Enumeration::DeviceInformation^ result;
           result = wrapper->_instance->GetAt(arg0);
           info.GetReturnValue().Set(WrapDeviceInformation(result));
@@ -4011,7 +4010,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4035,7 +4034,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Devices::Enumeration::DeviceInformation^ arg0 = UnwrapDeviceInformation(info[0]);
           unsigned int arg1;
-          
+
           bool result;
           result = wrapper->_instance->IndexOf(arg0, &arg1);
           Local<Object> resObj = Nan::New<Object>();
@@ -4050,7 +4049,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4078,7 +4077,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Foundation::Collections::IIterator<::Windows::Devices::Enumeration::DeviceInformation^>^ result;
           result = wrapper->_instance->First();
-          info.GetReturnValue().Set(NodeRT::Collections::IteratorWrapper<::Windows::Devices::Enumeration::DeviceInformation^>::CreateIteratorWrapper(result, 
+          info.GetReturnValue().Set(NodeRT::Collections::IteratorWrapper<::Windows::Devices::Enumeration::DeviceInformation^>::CreateIteratorWrapper(result,
             [](::Windows::Devices::Enumeration::DeviceInformation^ val) -> Local<Value> {
               return WrapDeviceInformation(val);
             }
@@ -4091,7 +4090,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4138,29 +4137,29 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceWatcher : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceWatcher").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "start", Start);
       Nan::SetPrototypeMethod(localRef, "stop", Stop);
       Nan::SetPrototypeMethod(localRef, "getBackgroundTrigger", GetBackgroundTrigger);
-      
-                  
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4175,13 +4174,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceWatcher(::Windows::Devices::Enumeration::DeviceWatcher^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4220,14 +4219,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceWatcher^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcher^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceWatcher^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4252,7 +4251,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4277,7 +4276,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
     static void Start(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4294,7 +4293,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           wrapper->_instance->Start();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -4302,7 +4301,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4324,7 +4323,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           wrapper->_instance->Stop();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -4332,7 +4331,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4354,12 +4353,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          ::Windows::Foundation::Collections::IIterable<::Windows::Devices::Enumeration::DeviceWatcherEventKind>^ arg0 = 
+          ::Windows::Foundation::Collections::IIterable<::Windows::Devices::Enumeration::DeviceWatcherEventKind>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Windows::Devices::Enumeration::DeviceWatcherEventKind>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Windows::Devices::Enumeration::DeviceWatcherEventKind>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Windows::Devices::Enumeration::DeviceWatcherEventKind>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsInt32();
                  },
@@ -4373,7 +4372,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                 return dynamic_cast<::Windows::Foundation::Collections::IIterable<::Windows::Devices::Enumeration::DeviceWatcherEventKind>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Windows::ApplicationModel::Background::DeviceWatcherTrigger^ result;
           result = wrapper->_instance->GetBackgroundTrigger(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.ApplicationModel.Background", "DeviceWatcherTrigger", result));
@@ -4385,7 +4384,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4397,7 +4396,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcher^>(info.This()))
       {
         return;
@@ -4405,7 +4404,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceWatcherStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -4417,7 +4416,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -4432,9 +4431,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"added", str))
       {
@@ -4444,12 +4443,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4501,12 +4500,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4558,12 +4557,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4615,12 +4614,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4672,12 +4671,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceWatcher *wrapper = DeviceWatcher::Unwrap<DeviceWatcher>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -4721,7 +4720,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -4764,7 +4763,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -4778,12 +4777,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"added", str))
         {
@@ -4879,26 +4878,26 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceInformation : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceInformation").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-            
+
       Nan::SetPrototypeMethod(localRef, "update", Update);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getThumbnailAsync", GetThumbnailAsync);
       Nan::SetPrototypeMethod(localRef, "getGlyphThumbnailAsync", GetGlyphThumbnailAsync);
-      
-                  
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("enclosureLocation").ToLocalChecked(), EnclosureLocationGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("id").ToLocalChecked(), IdGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isDefault").ToLocalChecked(), IsDefaultGetter);
@@ -4907,7 +4906,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("properties").ToLocalChecked(), PropertiesGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("kind").ToLocalChecked(), KindGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("pairing").ToLocalChecked(), PairingGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4928,13 +4927,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceInformation(::Windows::Devices::Enumeration::DeviceInformation^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4973,14 +4972,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceInformation^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceInformation^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -5005,7 +5004,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -5048,7 +5047,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceThumbnail^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -5062,17 +5061,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceThumbnail^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceThumbnail^> t)
+      {
         try
         {
           auto result = t.get();
@@ -5088,7 +5087,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5103,13 +5102,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void GetGlyphThumbnailAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -5130,7 +5129,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceThumbnail^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -5144,17 +5143,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceThumbnail^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceThumbnail^> t)
+      {
         try
         {
           auto result = t.get();
@@ -5170,7 +5169,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5185,16 +5184,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
     static void Update(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -5212,9 +5211,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceInformationUpdate^ arg0 = UnwrapDeviceInformationUpdate(info[0]);
-          
+
           wrapper->_instance->Update(arg0);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -5222,7 +5221,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5240,7 +5239,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceInformation^>^ op;
-      
+
 
       if (info.Length() == 4
         && info[0]->IsString()
@@ -5250,12 +5249,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5270,7 +5269,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               }
             } (info[1]);
           ::Windows::Devices::Enumeration::DeviceInformationKind arg2 = static_cast<::Windows::Devices::Enumeration::DeviceInformationKind>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(arg0,arg1,arg2);
         }
         catch (Platform::Exception ^exception)
@@ -5285,7 +5284,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5301,12 +5300,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5320,7 +5319,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                 return dynamic_cast<::Windows::Foundation::Collections::IIterable<::Platform::String^>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[1]);
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -5329,24 +5328,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformation^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformation^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -5355,7 +5354,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5370,13 +5369,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FindAllAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -5390,7 +5389,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceInformationCollection^>^ op;
-      
+
 
       if (info.Length() == 4
         && info[0]->IsString()
@@ -5400,12 +5399,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5420,7 +5419,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               }
             } (info[1]);
           ::Windows::Devices::Enumeration::DeviceInformationKind arg2 = static_cast<::Windows::Devices::Enumeration::DeviceInformationKind>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(arg0,arg1,arg2);
         }
         catch (Platform::Exception ^exception)
@@ -5447,7 +5446,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceClass arg0 = static_cast<::Windows::Devices::Enumeration::DeviceClass>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5462,7 +5461,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -5478,12 +5477,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5497,7 +5496,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                 return dynamic_cast<::Windows::Foundation::Collections::IIterable<::Platform::String^>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[1]);
-          
+
           op = ::Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -5506,24 +5505,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformationCollection^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceInformationCollection^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -5532,7 +5531,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -5547,13 +5546,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
 
@@ -5567,7 +5566,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceClass arg0 = static_cast<::Windows::Devices::Enumeration::DeviceClass>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           Platform::String^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::GetAqsFilterFromDeviceClass(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5579,7 +5578,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5597,12 +5596,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5617,7 +5616,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               }
             } (info[1]);
           ::Windows::Devices::Enumeration::DeviceInformationKind arg2 = static_cast<::Windows::Devices::Enumeration::DeviceInformationKind>(Nan::To<int32_t>(info[2]).FromMaybe(0));
-          
+
           ::Windows::Devices::Enumeration::DeviceWatcher^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(arg0, arg1, arg2);
           info.GetReturnValue().Set(WrapDeviceWatcher(result));
@@ -5650,7 +5649,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceClass arg0 = static_cast<::Windows::Devices::Enumeration::DeviceClass>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Devices::Enumeration::DeviceWatcher^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(arg0);
           info.GetReturnValue().Set(WrapDeviceWatcher(result));
@@ -5668,7 +5667,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           ::Windows::Devices::Enumeration::DeviceWatcher^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(arg0);
           info.GetReturnValue().Set(WrapDeviceWatcher(result));
@@ -5687,12 +5686,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
+          ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 =
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtVector<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -5706,7 +5705,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                 return dynamic_cast<::Windows::Foundation::Collections::IIterable<::Platform::String^>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[1]);
-          
+
           ::Windows::Devices::Enumeration::DeviceWatcher^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(arg0, arg1);
           info.GetReturnValue().Set(WrapDeviceWatcher(result));
@@ -5718,7 +5717,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5728,7 +5727,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void EnclosureLocationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5736,7 +5735,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::EnclosureLocation^ result = wrapper->_instance->EnclosureLocation;
         info.GetReturnValue().Set(WrapEnclosureLocation(result));
@@ -5748,11 +5747,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void IdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5760,7 +5759,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Id;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5772,11 +5771,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void IsDefaultGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5784,7 +5783,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsDefault;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -5796,11 +5795,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void IsEnabledGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5808,7 +5807,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsEnabled;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -5820,11 +5819,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5832,7 +5831,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -5844,11 +5843,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PropertiesGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5856,10 +5855,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IMapView<::Platform::String^, ::Platform::Object^>^ result = wrapper->_instance->Properties;
-        info.GetReturnValue().Set(NodeRT::Collections::MapViewWrapper<::Platform::String^,::Platform::Object^>::CreateMapViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::MapViewWrapper<::Platform::String^,::Platform::Object^>::CreateMapViewWrapper(result,
             [](::Platform::String^ val) -> Local<Value> {
               return NodeRT::Utils::NewString(val->Data());
             },
@@ -5881,11 +5880,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void KindGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5893,7 +5892,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformationKind result = wrapper->_instance->Kind;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -5905,11 +5904,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PairingGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformation^>(info.This()))
       {
         return;
@@ -5917,7 +5916,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformation *wrapper = DeviceInformation::Unwrap<DeviceInformation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformationPairing^ result = wrapper->_instance->Pairing;
         info.GetReturnValue().Set(WrapDeviceInformationPairing(result));
@@ -5929,7 +5928,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -5968,20 +5967,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DevicePairingResult : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DevicePairingResult").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("protectionLevelUsed").ToLocalChecked(), ProtectionLevelUsedGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -5996,13 +5995,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DevicePairingResult(::Windows::Devices::Enumeration::DevicePairingResult^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6041,14 +6040,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DevicePairingResult^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingResult^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DevicePairingResult^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6073,7 +6072,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6098,14 +6097,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void ProtectionLevelUsedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingResult^>(info.This()))
       {
         return;
@@ -6113,7 +6112,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePairingResult *wrapper = DevicePairingResult::Unwrap<DevicePairingResult>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePairingProtectionLevel result = wrapper->_instance->ProtectionLevelUsed;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -6125,11 +6124,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingResult^>(info.This()))
       {
         return;
@@ -6137,7 +6136,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePairingResult *wrapper = DevicePairingResult::Unwrap<DevicePairingResult>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePairingResultStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -6149,7 +6148,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -6188,19 +6187,19 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceUnpairingResult : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceUnpairingResult").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6215,13 +6214,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceUnpairingResult(::Windows::Devices::Enumeration::DeviceUnpairingResult^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6260,14 +6259,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceUnpairingResult^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceUnpairingResult^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceUnpairingResult^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6292,7 +6291,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6317,14 +6316,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceUnpairingResult^>(info.This()))
       {
         return;
@@ -6332,7 +6331,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceUnpairingResult *wrapper = DeviceUnpairingResult::Unwrap<DeviceUnpairingResult>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceUnpairingResultStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -6344,7 +6343,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -6383,17 +6382,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class IDevicePairingSettings : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IDevicePairingSettings").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6408,13 +6407,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     IDevicePairingSettings(::Windows::Devices::Enumeration::IDevicePairingSettings^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6453,14 +6452,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::IDevicePairingSettings^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::IDevicePairingSettings^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::IDevicePairingSettings^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6485,7 +6484,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6510,7 +6509,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
@@ -6552,25 +6551,25 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DevicePairingRequestedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DevicePairingRequestedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "accept", Accept);
       Nan::SetPrototypeMethod(localRef, "getDeferral", GetDeferral);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceInformation").ToLocalChecked(), DeviceInformationGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("pairingKind").ToLocalChecked(), PairingKindGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("pin").ToLocalChecked(), PinGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6585,13 +6584,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DevicePairingRequestedEventArgs(::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6630,14 +6629,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6662,7 +6661,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6687,7 +6686,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
     static void Accept(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6704,7 +6703,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           wrapper->_instance->Accept();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -6718,9 +6717,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           wrapper->_instance->Accept(arg0);
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -6728,7 +6727,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6760,7 +6759,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6772,7 +6771,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void DeviceInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^>(info.This()))
       {
         return;
@@ -6780,7 +6779,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePairingRequestedEventArgs *wrapper = DevicePairingRequestedEventArgs::Unwrap<DevicePairingRequestedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->DeviceInformation;
         info.GetReturnValue().Set(WrapDeviceInformation(result));
@@ -6792,11 +6791,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PairingKindGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^>(info.This()))
       {
         return;
@@ -6804,7 +6803,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePairingRequestedEventArgs *wrapper = DevicePairingRequestedEventArgs::Unwrap<DevicePairingRequestedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePairingKinds result = wrapper->_instance->PairingKind;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -6816,11 +6815,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void PinGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs^>(info.This()))
       {
         return;
@@ -6828,7 +6827,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DevicePairingRequestedEventArgs *wrapper = DevicePairingRequestedEventArgs::Unwrap<DevicePairingRequestedEventArgs>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Pin;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6840,7 +6839,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -6879,27 +6878,27 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceInformationCustomPairing : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceInformationCustomPairing").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-                  
+
       Nan::SetPrototypeMethod(localRef, "pairAsync", PairAsync);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6914,13 +6913,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceInformationCustomPairing(::Windows::Devices::Enumeration::DeviceInformationCustomPairing^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6959,14 +6958,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceInformationCustomPairing^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationCustomPairing^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceInformationCustomPairing^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6991,7 +6990,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -7034,7 +7033,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceInformationCustomPairing *wrapper = DeviceInformationCustomPairing::Unwrap<DeviceInformationCustomPairing>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DevicePairingResult^>^ op;
-    
+
 
       if (info.Length() == 2
         && info[0]->IsInt32())
@@ -7042,7 +7041,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DevicePairingKinds arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingKinds>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = wrapper->_instance->PairAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -7059,7 +7058,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Devices::Enumeration::DevicePairingKinds arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingKinds>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Enumeration::DevicePairingProtectionLevel arg1 = static_cast<::Windows::Devices::Enumeration::DevicePairingProtectionLevel>(Nan::To<int32_t>(info[1]).FromMaybe(0));
-          
+
           op = wrapper->_instance->PairAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -7078,7 +7077,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           ::Windows::Devices::Enumeration::DevicePairingKinds arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingKinds>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Enumeration::DevicePairingProtectionLevel arg1 = static_cast<::Windows::Devices::Enumeration::DevicePairingProtectionLevel>(Nan::To<int32_t>(info[1]).FromMaybe(0));
           ::Windows::Devices::Enumeration::IDevicePairingSettings^ arg2 = UnwrapIDevicePairingSettings(info[2]);
-          
+
           op = wrapper->_instance->PairAsync(arg0,arg1,arg2);
         }
         catch (Platform::Exception ^exception)
@@ -7087,17 +7086,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DevicePairingResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DevicePairingResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -7113,7 +7112,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -7128,16 +7127,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
 
 
 
@@ -7155,9 +7154,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"pairingRequested", str))
       {
@@ -7167,12 +7166,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceInformationCustomPairing *wrapper = DeviceInformationCustomPairing::Unwrap<DeviceInformationCustomPairing>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -7216,7 +7215,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -7259,7 +7258,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -7273,12 +7272,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"pairingRequested", str))
         {
@@ -7334,28 +7333,28 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceInformationPairing : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceInformationPairing").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-                  
+
       Nan::SetPrototypeMethod(localRef, "pairAsync", PairAsync);
       Nan::SetPrototypeMethod(localRef, "unpairAsync", UnpairAsync);
-      
-                  
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("canPair").ToLocalChecked(), CanPairGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isPaired").ToLocalChecked(), IsPairedGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("custom").ToLocalChecked(), CustomGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("protectionLevel").ToLocalChecked(), ProtectionLevelGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -7371,13 +7370,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceInformationPairing(::Windows::Devices::Enumeration::DeviceInformationPairing^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -7416,14 +7415,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceInformationPairing^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationPairing^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceInformationPairing^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -7448,7 +7447,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -7491,7 +7490,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DevicePairingResult^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -7511,7 +7510,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DevicePairingProtectionLevel arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingProtectionLevel>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = wrapper->_instance->PairAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -7528,7 +7527,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         {
           ::Windows::Devices::Enumeration::DevicePairingProtectionLevel arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingProtectionLevel>(Nan::To<int32_t>(info[0]).FromMaybe(0));
           ::Windows::Devices::Enumeration::IDevicePairingSettings^ arg1 = UnwrapIDevicePairingSettings(info[1]);
-          
+
           op = wrapper->_instance->PairAsync(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -7537,17 +7536,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DevicePairingResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DevicePairingResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -7563,7 +7562,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -7578,13 +7577,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void UnpairAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -7605,7 +7604,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Enumeration::DeviceUnpairingResult^>^ op;
-    
+
 
       if (info.Length() == 1)
       {
@@ -7619,17 +7618,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceUnpairingResult^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Enumeration::DeviceUnpairingResult^> t)
+      {
         try
         {
           auto result = t.get();
@@ -7645,7 +7644,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -7660,16 +7659,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
 
 
     static void TryRegisterForAllInboundPairingRequests(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -7682,7 +7681,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DevicePairingKinds arg0 = static_cast<::Windows::Devices::Enumeration::DevicePairingKinds>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           bool result;
           result = ::Windows::Devices::Enumeration::DeviceInformationPairing::TryRegisterForAllInboundPairingRequests(arg0);
           info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -7694,7 +7693,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -7704,7 +7703,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void CanPairGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationPairing^>(info.This()))
       {
         return;
@@ -7712,7 +7711,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->CanPair;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -7724,11 +7723,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void IsPairedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationPairing^>(info.This()))
       {
         return;
@@ -7736,7 +7735,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsPaired;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -7748,11 +7747,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void CustomGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationPairing^>(info.This()))
       {
         return;
@@ -7760,7 +7759,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformationCustomPairing^ result = wrapper->_instance->Custom;
         info.GetReturnValue().Set(WrapDeviceInformationCustomPairing(result));
@@ -7772,11 +7771,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void ProtectionLevelGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceInformationPairing^>(info.This()))
       {
         return;
@@ -7784,7 +7783,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceInformationPairing *wrapper = DeviceInformationPairing::Unwrap<DeviceInformationPairing>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DevicePairingProtectionLevel result = wrapper->_instance->ProtectionLevel;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -7796,7 +7795,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -7835,20 +7834,20 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceAccessChangedEventArgs : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceAccessChangedEventArgs").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("id").ToLocalChecked(), IdGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -7863,13 +7862,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceAccessChangedEventArgs(::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -7908,14 +7907,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -7940,7 +7939,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -7965,14 +7964,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^>(info.This()))
       {
         return;
@@ -7980,7 +7979,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceAccessChangedEventArgs *wrapper = DeviceAccessChangedEventArgs::Unwrap<DeviceAccessChangedEventArgs>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceAccessStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -7992,11 +7991,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void IdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceAccessChangedEventArgs^>(info.This()))
       {
         return;
@@ -8004,7 +8003,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceAccessChangedEventArgs *wrapper = DeviceAccessChangedEventArgs::Unwrap<DeviceAccessChangedEventArgs>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Id;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -8016,7 +8015,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -8055,24 +8054,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceAccessInformation : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceAccessInformation").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                        
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("currentStatus").ToLocalChecked(), CurrentStatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -8090,13 +8089,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceAccessInformation(::Windows::Devices::Enumeration::DeviceAccessInformation^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -8135,14 +8134,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceAccessInformation^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceAccessInformation^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceAccessInformation^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -8167,7 +8166,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -8192,7 +8191,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
     static void CreateFromId(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -8205,7 +8204,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           ::Windows::Devices::Enumeration::DeviceAccessInformation^ result;
           result = ::Windows::Devices::Enumeration::DeviceAccessInformation::CreateFromId(arg0);
           info.GetReturnValue().Set(WrapDeviceAccessInformation(result));
@@ -8217,7 +8216,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -8233,7 +8232,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
-          
+
           ::Windows::Devices::Enumeration::DeviceAccessInformation^ result;
           result = ::Windows::Devices::Enumeration::DeviceAccessInformation::CreateFromDeviceClassId(arg0);
           info.GetReturnValue().Set(WrapDeviceAccessInformation(result));
@@ -8245,7 +8244,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -8261,7 +8260,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceClass arg0 = static_cast<::Windows::Devices::Enumeration::DeviceClass>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Devices::Enumeration::DeviceAccessInformation^ result;
           result = ::Windows::Devices::Enumeration::DeviceAccessInformation::CreateFromDeviceClass(arg0);
           info.GetReturnValue().Set(WrapDeviceAccessInformation(result));
@@ -8273,7 +8272,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -8283,7 +8282,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     static void CurrentStatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceAccessInformation^>(info.This()))
       {
         return;
@@ -8291,7 +8290,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceAccessInformation *wrapper = DeviceAccessInformation::Unwrap<DeviceAccessInformation>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceAccessStatus result = wrapper->_instance->CurrentStatus;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -8303,7 +8302,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -8318,9 +8317,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"accessChanged", str))
       {
@@ -8330,12 +8329,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		  return;
         }
         DeviceAccessInformation *wrapper = DeviceAccessInformation::Unwrap<DeviceAccessInformation>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -8379,7 +8378,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -8422,7 +8421,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -8436,12 +8435,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"accessChanged", str))
         {
@@ -8497,21 +8496,21 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceWatcherEvent : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceWatcherEvent").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceInformation").ToLocalChecked(), DeviceInformationGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceInformationUpdate").ToLocalChecked(), DeviceInformationUpdateGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("kind").ToLocalChecked(), KindGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -8526,13 +8525,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceWatcherEvent(::Windows::Devices::Enumeration::DeviceWatcherEvent^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -8571,14 +8570,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceWatcherEvent^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherEvent^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceWatcherEvent^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -8603,7 +8602,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -8628,14 +8627,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void DeviceInformationGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherEvent^>(info.This()))
       {
         return;
@@ -8643,7 +8642,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceWatcherEvent *wrapper = DeviceWatcherEvent::Unwrap<DeviceWatcherEvent>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformation^ result = wrapper->_instance->DeviceInformation;
         info.GetReturnValue().Set(WrapDeviceInformation(result));
@@ -8655,11 +8654,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void DeviceInformationUpdateGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherEvent^>(info.This()))
       {
         return;
@@ -8667,7 +8666,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceWatcherEvent *wrapper = DeviceWatcherEvent::Unwrap<DeviceWatcherEvent>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceInformationUpdate^ result = wrapper->_instance->DeviceInformationUpdate;
         info.GetReturnValue().Set(WrapDeviceInformationUpdate(result));
@@ -8679,11 +8678,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
     static void KindGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherEvent^>(info.This()))
       {
         return;
@@ -8691,7 +8690,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceWatcherEvent *wrapper = DeviceWatcherEvent::Unwrap<DeviceWatcherEvent>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Enumeration::DeviceWatcherEventKind result = wrapper->_instance->Kind;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -8703,7 +8702,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -8742,19 +8741,19 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
   class DeviceWatcherTriggerDetails : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("DeviceWatcherTriggerDetails").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("deviceWatcherEvents").ToLocalChecked(), DeviceWatcherEventsGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -8769,13 +8768,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
   private:
-    
+
     DeviceWatcherTriggerDetails(::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -8814,14 +8813,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
           return;
         }
       }
-      
+
       ::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -8846,7 +8845,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -8871,14 +8870,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     }
 
 
-  
+
 
 
 
     static void DeviceWatcherEventsGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Enumeration::DeviceWatcherTriggerDetails^>(info.This()))
       {
         return;
@@ -8886,10 +8885,10 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 
       DeviceWatcherTriggerDetails *wrapper = DeviceWatcherTriggerDetails::Unwrap<DeviceWatcherTriggerDetails>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Enumeration::DeviceWatcherEvent^>^ result = wrapper->_instance->DeviceWatcherEvents;
-        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Enumeration::DeviceWatcherEvent^>::CreateVectorViewWrapper(result, 
+        info.GetReturnValue().Set(NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Enumeration::DeviceWatcherEvent^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Enumeration::DeviceWatcherEvent^ val) -> Local<Value> {
               return WrapDeviceWatcherEvent(val);
             },
@@ -8908,7 +8907,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
     }
-    
+
 
 
   private:
@@ -8945,7 +8944,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
     DeviceWatcherTriggerDetails::Init(exports);
   }
 
-} } } } 
+} } } }
 
 NAN_MODULE_INIT(init)
 {
@@ -8956,7 +8955,7 @@ NAN_MODULE_INIT(init)
     Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"error in CoInitializeEx()")));
     return;
   }*/
-  
+
   NodeRT::Windows::Devices::Enumeration::InitDevicePickerDisplayStatusOptionsEnum(target);
   NodeRT::Windows::Devices::Enumeration::InitDeviceClassEnum(target);
   NodeRT::Windows::Devices::Enumeration::InitDeviceWatcherStatusEnum(target);

--- a/uwp/windows.devices.enumeration/node-async.h
+++ b/uwp/windows.devices.enumeration/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.devices.enumeration/node-async.h
+++ b/uwp/windows.devices.enumeration/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.devices.radios/CollectionsWrap.h
+++ b/uwp/windows.devices.radios/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.devices.radios/NodeRtUtils.cpp
+++ b/uwp/windows.devices.radios/NodeRtUtils.cpp
@@ -195,7 +195,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.devices.radios/NodeRtUtils.cpp
+++ b/uwp/windows.devices.radios/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,8 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
-  using v8::Value;
   using v8::Boolean;
   using v8::Integer;
   using v8::FunctionTemplate;
@@ -77,12 +75,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +103,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +182,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +296,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +348,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +379,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +460,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +530,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +588,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +669,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.devices.radios/NodeRtUtils.cpp
+++ b/uwp/windows.devices.radios/NodeRtUtils.cpp
@@ -19,6 +19,7 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
+  using v8::Value;
   using v8::Boolean;
   using v8::Integer;
   using v8::FunctionTemplate;

--- a/uwp/windows.devices.radios/OpaqueWrapper.h
+++ b/uwp/windows.devices.radios/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.devices.radios/_nodert_generated.cpp
+++ b/uwp/windows.devices.radios/_nodert_generated.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -59,17 +58,17 @@ using Nan::HandleScope;
 using Nan::TryCatch;
 using namespace concurrency;
 
-namespace NodeRT { namespace Windows { namespace Devices { namespace Radios { 
+namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
   v8::Local<v8::Value> WrapRadio(::Windows::Devices::Radios::Radio^ wintRtInstance);
   ::Windows::Devices::Radios::Radio^ UnwrapRadio(Local<Value> value);
-  
+
 
 
   static void InitRadioStateEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("RadioState").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unknown").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Radios::RadioState::Unknown)));
@@ -82,7 +81,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
   static void InitRadioKindEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("RadioKind").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("other").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Radios::RadioKind::Other)));
@@ -96,7 +95,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
   static void InitRadioAccessStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("RadioAccessStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("unspecified").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Devices::Radios::RadioAccessStatus::Unspecified)));
@@ -107,34 +106,34 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
 
 
-  
+
   class Radio : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("Radio").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
+
       Local<Function> func;
       Local<FunctionTemplate> funcTemplate;
-                  
+
       Nan::SetPrototypeMethod(localRef, "setStateAsync", SetStateAsync);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("kind").ToLocalChecked(), KindGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("name").ToLocalChecked(), NameGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("state").ToLocalChecked(), StateGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -156,13 +155,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
     }
 
   private:
-    
+
     Radio(::Windows::Devices::Radios::Radio^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -201,14 +200,14 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      
+
       ::Windows::Devices::Radios::Radio^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Radios::Radio^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Devices::Radios::Radio^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -233,7 +232,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -276,7 +275,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       Radio *wrapper = Radio::Unwrap<Radio>(info.This());
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Radios::RadioAccessStatus>^ op;
-    
+
 
       if (info.Length() == 2
         && info[0]->IsInt32())
@@ -284,7 +283,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         try
         {
           ::Windows::Devices::Radios::RadioState arg0 = static_cast<::Windows::Devices::Radios::RadioState>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           op = wrapper->_instance->SetStateAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -293,17 +292,17 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::RadioAccessStatus> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::RadioAccessStatus> t)
+      {
         try
         {
           auto result = t.get();
@@ -319,7 +318,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -334,16 +333,16 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-             
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
-  
+
 
     static void GetRadiosAsync(Nan::NAN_METHOD_ARGS_TYPE info)
     {
@@ -356,7 +355,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Radios::Radio^>^>^ op;
-      
+
 
       if (info.Length() == 1)
       {
@@ -370,28 +369,28 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Radios::Radio^>^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Foundation::Collections::IVectorView<::Windows::Devices::Radios::Radio^>^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
-              arg1 = NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Radios::Radio^>::CreateVectorViewWrapper(result, 
+              arg1 = NodeRT::Collections::VectorViewWrapper<::Windows::Devices::Radios::Radio^>::CreateVectorViewWrapper(result,
             [](::Windows::Devices::Radios::Radio^ val) -> Local<Value> {
               return WrapRadio(val);
             },
@@ -406,7 +405,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -421,13 +420,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void FromIdAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -441,7 +440,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Radios::Radio^>^ op;
-      
+
 
       if (info.Length() == 2
         && info[0]->IsString())
@@ -449,7 +448,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           op = ::Windows::Devices::Radios::Radio::FromIdAsync(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -458,24 +457,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::Radio^> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::Radio^> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -484,7 +483,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -499,13 +498,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
     static void RequestAccessAsync(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -519,7 +518,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       }
 
       ::Windows::Foundation::IAsyncOperation<::Windows::Devices::Radios::RadioAccessStatus>^ op;
-      
+
 
       if (info.Length() == 1)
       {
@@ -533,24 +532,24 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
       }
-    
+
       auto opTask = create_task(op);
       uv_async_t* asyncToken = NodeUtils::Async::GetAsyncToken(info[info.Length() -1].As<Function>());
 
-      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::RadioAccessStatus> t) 
-      {	
+      opTask.then( [asyncToken] (task<::Windows::Devices::Radios::RadioAccessStatus> t)
+      {
         try
         {
           auto result = t.get();
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [result](NodeUtils::InvokeCallbackDelegate invokeCallback) {
 
-            
-            Local<Value> error; 
+
+            Local<Value> error;
             Local<Value> arg1;
             {
               TryCatch tryCatch;
@@ -559,7 +558,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
               {
                 error = Nan::To<Object>(tryCatch.Exception()).ToLocalChecked();
               }
-              else 
+              else
               {
                 error = Undefined();
               }
@@ -574,13 +573,13 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         catch (Platform::Exception^ exception)
         {
           NodeUtils::Async::RunCallbackOnMain(asyncToken, [exception](NodeUtils::InvokeCallbackDelegate invokeCallback) {
-          
+
             Local<Value> error = NodeRT::Utils::WinRtExceptionToJsError(exception);
-        
+
             Local<Value> args[] = {error};
             invokeCallback(_countof(args), args);
           });
-        }  		
+        }
       });
     }
 
@@ -603,7 +602,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -613,7 +612,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
     static void KindGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Radios::Radio^>(info.This()))
       {
         return;
@@ -621,7 +620,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
       Radio *wrapper = Radio::Unwrap<Radio>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Radios::RadioKind result = wrapper->_instance->Kind;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -633,11 +632,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         return;
       }
     }
-    
+
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Radios::Radio^>(info.This()))
       {
         return;
@@ -645,7 +644,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
       Radio *wrapper = Radio::Unwrap<Radio>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -657,11 +656,11 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         return;
       }
     }
-    
+
     static void StateGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Devices::Radios::Radio^>(info.This()))
       {
         return;
@@ -669,7 +668,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
       Radio *wrapper = Radio::Unwrap<Radio>(info.This());
 
-      try 
+      try
       {
         ::Windows::Devices::Radios::RadioState result = wrapper->_instance->State;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -681,7 +680,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -696,9 +695,9 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"stateChanged", str))
       {
@@ -708,12 +707,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 		  return;
         }
         Radio *wrapper = Radio::Unwrap<Radio>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -757,7 +756,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -800,7 +799,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -814,12 +813,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"stateChanged", str))
         {
@@ -873,7 +872,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
     Radio::Init(exports);
   }
 
-} } } } 
+} } } }
 
 NAN_MODULE_INIT(init)
 {
@@ -884,7 +883,7 @@ NAN_MODULE_INIT(init)
     Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"error in CoInitializeEx()")));
     return;
   }*/
-  
+
   NodeRT::Windows::Devices::Radios::InitRadioStateEnum(target);
   NodeRT::Windows::Devices::Radios::InitRadioKindEnum(target);
   NodeRT::Windows::Devices::Radios::InitRadioAccessStatusEnum(target);

--- a/uwp/windows.devices.radios/node-async.h
+++ b/uwp/windows.devices.radios/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.devices.radios/node-async.h
+++ b/uwp/windows.devices.radios/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.foundation/CollectionsWrap.h
+++ b/uwp/windows.foundation/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.foundation/NodeRtUtils.cpp
+++ b/uwp/windows.foundation/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.foundation/NodeRtUtils.cpp
+++ b/uwp/windows.foundation/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.foundation/OpaqueWrapper.h
+++ b/uwp/windows.foundation/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.foundation/_nodert_generated.cpp
+++ b/uwp/windows.foundation/_nodert_generated.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -59,56 +58,56 @@ using Nan::HandleScope;
 using Nan::TryCatch;
 using namespace concurrency;
 
-namespace NodeRT { namespace Windows { namespace Foundation { 
+namespace NodeRT { namespace Windows { namespace Foundation {
 
   v8::Local<v8::Value> WrapPropertyValue(::Windows::Foundation::PropertyValue^ wintRtInstance);
   ::Windows::Foundation::PropertyValue^ UnwrapPropertyValue(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIStringable(::Windows::Foundation::IStringable^ wintRtInstance);
   ::Windows::Foundation::IStringable^ UnwrapIStringable(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapDeferral(::Windows::Foundation::Deferral^ wintRtInstance);
   ::Windows::Foundation::Deferral^ UnwrapDeferral(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIAsyncInfo(::Windows::Foundation::IAsyncInfo^ wintRtInstance);
   ::Windows::Foundation::IAsyncInfo^ UnwrapIAsyncInfo(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIAsyncAction(::Windows::Foundation::IAsyncAction^ wintRtInstance);
   ::Windows::Foundation::IAsyncAction^ UnwrapIAsyncAction(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIMemoryBufferReference(::Windows::Foundation::IMemoryBufferReference^ wintRtInstance);
   ::Windows::Foundation::IMemoryBufferReference^ UnwrapIMemoryBufferReference(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIMemoryBuffer(::Windows::Foundation::IMemoryBuffer^ wintRtInstance);
   ::Windows::Foundation::IMemoryBuffer^ UnwrapIMemoryBuffer(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapMemoryBuffer(::Windows::Foundation::MemoryBuffer^ wintRtInstance);
   ::Windows::Foundation::MemoryBuffer^ UnwrapMemoryBuffer(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapWwwFormUrlDecoder(::Windows::Foundation::WwwFormUrlDecoder^ wintRtInstance);
   ::Windows::Foundation::WwwFormUrlDecoder^ UnwrapWwwFormUrlDecoder(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIWwwFormUrlDecoderEntry(::Windows::Foundation::IWwwFormUrlDecoderEntry^ wintRtInstance);
   ::Windows::Foundation::IWwwFormUrlDecoderEntry^ UnwrapIWwwFormUrlDecoderEntry(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapWwwFormUrlDecoderEntry(::Windows::Foundation::WwwFormUrlDecoderEntry^ wintRtInstance);
   ::Windows::Foundation::WwwFormUrlDecoderEntry^ UnwrapWwwFormUrlDecoderEntry(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIGetActivationFactory(::Windows::Foundation::IGetActivationFactory^ wintRtInstance);
   ::Windows::Foundation::IGetActivationFactory^ UnwrapIGetActivationFactory(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapIPropertyValue(::Windows::Foundation::IPropertyValue^ wintRtInstance);
   ::Windows::Foundation::IPropertyValue^ UnwrapIPropertyValue(Local<Value> value);
-  
+
   v8::Local<v8::Value> WrapUri(::Windows::Foundation::Uri^ wintRtInstance);
   ::Windows::Foundation::Uri^ UnwrapUri(Local<Value> value);
-  
+
 
 
   static void InitPropertyTypeEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("PropertyType").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("empty").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Foundation::PropertyType::Empty)));
@@ -158,7 +157,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
   static void InitAsyncStatusEnum(const Local<Object> exports)
   {
     HandleScope scope;
-    
+
 	Local<Object> enumObject = Nan::New<Object>();
     Nan::Set(exports, Nan::New<String>("AsyncStatus").ToLocalChecked(), enumObject);
 	Nan::Set(enumObject, Nan::New<String>("started").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(::Windows::Foundation::AsyncStatus::Started)));
@@ -169,7 +168,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
 
 
-  
+
   static bool IsFoundationContractJsObject(Local<Value> value)
   {
     if (!value->IsObject())
@@ -187,7 +186,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
   {
     HandleScope scope;
     ::Windows::Foundation::FoundationContract returnValue;
-    
+
     if (!value->IsObject())
     {
       Nan::ThrowError(Nan::TypeError(NodeRT::Utils::NewString(L"Unexpected type, expected an object")));
@@ -206,11 +205,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
     Local<Object> obj = Nan::New<Object>();
 
-    
+
     return scope.Escape(obj);
   }
 
-  
+
   static bool IsUniversalApiContractJsObject(Local<Value> value)
   {
     if (!value->IsObject())
@@ -228,7 +227,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
   {
     HandleScope scope;
     ::Windows::Foundation::UniversalApiContract returnValue;
-    
+
     if (!value->IsObject())
     {
       Nan::ThrowError(Nan::TypeError(NodeRT::Utils::NewString(L"Unexpected type, expected an object")));
@@ -247,24 +246,24 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
     Local<Object> obj = Nan::New<Object>();
 
-    
+
     return scope.Escape(obj);
   }
 
-  
+
   class PropertyValue : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("PropertyValue").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -318,13 +317,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     PropertyValue(::Windows::Foundation::PropertyValue^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -363,14 +362,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::PropertyValue^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::PropertyValue^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::PropertyValue^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -395,7 +394,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -420,7 +419,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
 
 
     static void CreateEmpty(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -442,7 +441,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -458,7 +457,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned char arg0 = static_cast<unsigned char>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt8(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -470,7 +469,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -486,7 +485,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           short arg0 = static_cast<short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt16(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -498,7 +497,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -514,7 +513,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned short arg0 = static_cast<unsigned short>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt16(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -526,7 +525,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -542,7 +541,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           int arg0 = static_cast<int>(Nan::To<int32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt32(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -554,7 +553,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -570,7 +569,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt32(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -582,7 +581,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -598,7 +597,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           __int64 arg0 = Nan::To<int64_t>(info[0]).FromMaybe(0);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt64(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -610,7 +609,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -626,7 +625,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned __int64 arg0 = static_cast<unsigned __int64>(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt64(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -638,7 +637,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -654,7 +653,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           float arg0 = static_cast<float>(Nan::To<double>(info[0]).FromMaybe(0.0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateSingle(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -666,7 +665,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -682,7 +681,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           double arg0 = Nan::To<double>(info[0]).FromMaybe(0.0);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateDouble(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -694,7 +693,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -710,7 +709,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           wchar_t arg0 = NodeRT::Utils::GetFirstChar(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateChar16(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -722,7 +721,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -738,7 +737,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           bool arg0 = Nan::To<bool>(info[0]).FromMaybe(false);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateBoolean(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -750,7 +749,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -766,7 +765,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateString(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -778,7 +777,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -794,7 +793,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Object^ arg0 = dynamic_cast<::Platform::Object^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInspectable(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -806,7 +805,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -822,7 +821,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Guid arg0 = NodeRT::Utils::GuidFromJs(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateGuid(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -834,7 +833,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -850,7 +849,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::DateTime arg0 = NodeRT::Utils::DateTimeFromJSDate(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateDateTime(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -862,7 +861,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -878,7 +877,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::TimeSpan arg0 = NodeRT::Utils::TimeSpanFromMilli(Nan::To<int64_t>(info[0]).FromMaybe(0));
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateTimeSpan(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -890,7 +889,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -906,7 +905,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::Point arg0 = NodeRT::Utils::PointFromJs(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreatePoint(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -918,7 +917,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -934,7 +933,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::Size arg0 = NodeRT::Utils::SizeFromJs(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateSize(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -946,7 +945,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -962,7 +961,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::Rect arg0 = NodeRT::Utils::RectFromJs(info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateRect(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -974,7 +973,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -989,12 +988,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<unsigned char>^ arg0 = 
+          ::Platform::Array<unsigned char>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<unsigned char>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<unsigned char>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<unsigned char>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsInt32();
                  },
@@ -1008,7 +1007,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<unsigned char>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt8Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1020,7 +1019,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1035,12 +1034,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<short>^ arg0 = 
+          ::Platform::Array<short>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<short>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<short>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<short>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsInt32();
                  },
@@ -1054,7 +1053,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<short>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt16Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1066,7 +1065,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1081,12 +1080,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<unsigned short>^ arg0 = 
+          ::Platform::Array<unsigned short>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<unsigned short>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<unsigned short>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<unsigned short>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsInt32();
                  },
@@ -1100,7 +1099,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<unsigned short>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt16Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1112,7 +1111,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1127,12 +1126,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<int>^ arg0 = 
+          ::Platform::Array<int>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<int>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<int>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<int>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsInt32();
                  },
@@ -1146,7 +1145,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<int>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt32Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1158,7 +1157,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1173,12 +1172,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<unsigned int>^ arg0 = 
+          ::Platform::Array<unsigned int>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<unsigned int>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<unsigned int>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<unsigned int>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsUint32();
                  },
@@ -1192,7 +1191,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<unsigned int>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt32Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1204,7 +1203,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1219,12 +1218,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<__int64>^ arg0 = 
+          ::Platform::Array<__int64>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<__int64>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<__int64>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<__int64>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsNumber();
                  },
@@ -1238,7 +1237,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<__int64>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInt64Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1250,7 +1249,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1265,12 +1264,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<unsigned __int64>^ arg0 = 
+          ::Platform::Array<unsigned __int64>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<unsigned __int64>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<unsigned __int64>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<unsigned __int64>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsNumber();
                  },
@@ -1284,7 +1283,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<unsigned __int64>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateUInt64Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1296,7 +1295,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1311,12 +1310,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<float>^ arg0 = 
+          ::Platform::Array<float>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<float>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<float>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<float>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsNumber();
                  },
@@ -1330,7 +1329,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<float>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateSingleArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1342,7 +1341,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1357,12 +1356,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<double>^ arg0 = 
+          ::Platform::Array<double>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<double>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<double>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<double>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsNumber();
                  },
@@ -1376,7 +1375,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<double>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateDoubleArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1388,7 +1387,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1403,12 +1402,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<wchar_t>^ arg0 = 
+          ::Platform::Array<wchar_t>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<wchar_t>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<wchar_t>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<wchar_t>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsString();
                  },
@@ -1422,7 +1421,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<wchar_t>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateChar16Array(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1434,7 +1433,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1449,12 +1448,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<bool>^ arg0 = 
+          ::Platform::Array<bool>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<bool>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<bool>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<bool>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsBoolean();
                  },
@@ -1468,7 +1467,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<bool>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateBooleanArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1480,7 +1479,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1495,12 +1494,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Platform::String^>^ arg0 = 
+          ::Platform::Array<::Platform::String^>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Platform::String^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::String^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::String^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
@@ -1514,7 +1513,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Platform::String^>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateStringArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1526,7 +1525,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1541,12 +1540,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Platform::Object^>^ arg0 = 
+          ::Platform::Array<::Platform::Object^>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Platform::Object^>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::Object^>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::Object^>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return NodeRT::Utils::IsWinRtWrapperOf<::Platform::Object^>(value);
                  },
@@ -1560,7 +1559,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Platform::Object^>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateInspectableArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1572,7 +1571,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1587,12 +1586,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Platform::Guid>^ arg0 = 
+          ::Platform::Array<::Platform::Guid>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Platform::Guid>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::Guid>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Platform::Guid>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return NodeRT::Utils::IsGuid(value);
                  },
@@ -1606,7 +1605,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Platform::Guid>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateGuidArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1618,7 +1617,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1633,12 +1632,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Windows::Foundation::DateTime>^ arg0 = 
+          ::Platform::Array<::Windows::Foundation::DateTime>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Windows::Foundation::DateTime>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::DateTime>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::DateTime>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsDate();
                  },
@@ -1652,7 +1651,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Windows::Foundation::DateTime>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateDateTimeArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1664,7 +1663,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1679,12 +1678,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Windows::Foundation::TimeSpan>^ arg0 = 
+          ::Platform::Array<::Windows::Foundation::TimeSpan>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Windows::Foundation::TimeSpan>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::TimeSpan>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::TimeSpan>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return value->IsNumber();
                  },
@@ -1698,7 +1697,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Windows::Foundation::TimeSpan>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateTimeSpanArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1710,7 +1709,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1725,12 +1724,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Windows::Foundation::Point>^ arg0 = 
+          ::Platform::Array<::Windows::Foundation::Point>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Windows::Foundation::Point>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Point>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Point>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return NodeRT::Utils::IsPoint(value);
                  },
@@ -1744,7 +1743,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Windows::Foundation::Point>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreatePointArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1756,7 +1755,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1771,12 +1770,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Windows::Foundation::Size>^ arg0 = 
+          ::Platform::Array<::Windows::Foundation::Size>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Windows::Foundation::Size>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Size>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Size>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return NodeRT::Utils::IsSize(value);
                  },
@@ -1790,7 +1789,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Windows::Foundation::Size>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateSizeArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1802,7 +1801,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1817,12 +1816,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          ::Platform::Array<::Windows::Foundation::Rect>^ arg0 = 
+          ::Platform::Array<::Windows::Foundation::Rect>^ arg0 =
             [] (v8::Local<v8::Value> value) -> ::Platform::Array<::Windows::Foundation::Rect>^
             {
               if (value->IsArray())
               {
-                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Rect>(value.As<Array>(), 
+                return NodeRT::Collections::JsArrayToWinrtArray<::Windows::Foundation::Rect>(value.As<Array>(),
                  [](Local<Value> value) -> bool {
                    return NodeRT::Utils::IsRect(value);
                  },
@@ -1836,7 +1835,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                 return dynamic_cast<::Platform::Array<::Windows::Foundation::Rect>^>(NodeRT::Utils::GetObjectInstance(value));
               }
             } (info[0]);
-          
+
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateRectArray(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -1848,7 +1847,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -1893,20 +1892,20 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IStringable : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IStringable").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "toString", ToString);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -1921,13 +1920,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IStringable(::Windows::Foundation::IStringable^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -1966,14 +1965,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IStringable^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IStringable^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IStringable^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -1998,7 +1997,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2023,7 +2022,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void ToString(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2050,7 +2049,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2097,21 +2096,21 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class Deferral : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("Deferral").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "complete", Complete);
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2126,13 +2125,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     Deferral(::Windows::Foundation::Deferral^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2171,14 +2170,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::Deferral^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Deferral^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::Deferral^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2194,7 +2193,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::DeferralCompletedHandler^ arg0 = dynamic_cast<::Windows::Foundation::DeferralCompletedHandler^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           winRtInstance = ref new ::Windows::Foundation::Deferral(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -2218,7 +2217,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2243,7 +2242,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void Complete(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2260,7 +2259,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           wrapper->_instance->Complete();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2268,7 +2267,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2299,7 +2298,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 		  return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
 		return;
@@ -2347,25 +2346,25 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IAsyncInfo : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IAsyncInfo").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "cancel", Cancel);
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("errorCode").ToLocalChecked(), ErrorCodeGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("id").ToLocalChecked(), IdGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("status").ToLocalChecked(), StatusGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2380,13 +2379,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IAsyncInfo(::Windows::Foundation::IAsyncInfo^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2425,14 +2424,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IAsyncInfo^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncInfo^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IAsyncInfo^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2457,7 +2456,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2482,7 +2481,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void Cancel(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2499,7 +2498,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           wrapper->_instance->Cancel();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2507,7 +2506,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2529,7 +2528,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           wrapper->_instance->Close();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2537,7 +2536,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2549,7 +2548,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     static void ErrorCodeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncInfo^>(info.This()))
       {
         return;
@@ -2557,7 +2556,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IAsyncInfo *wrapper = IAsyncInfo::Unwrap<IAsyncInfo>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::HResult result = wrapper->_instance->ErrorCode;
         info.GetReturnValue().Set(Nan::New<Integer>(result.Value));
@@ -2569,11 +2568,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void IdGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncInfo^>(info.This()))
       {
         return;
@@ -2581,7 +2580,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IAsyncInfo *wrapper = IAsyncInfo::Unwrap<IAsyncInfo>(info.This());
 
-      try 
+      try
       {
         unsigned int result = wrapper->_instance->Id;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -2593,11 +2592,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void StatusGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncInfo^>(info.This()))
       {
         return;
@@ -2605,7 +2604,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IAsyncInfo *wrapper = IAsyncInfo::Unwrap<IAsyncInfo>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::AsyncStatus result = wrapper->_instance->Status;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -2617,7 +2616,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
   private:
@@ -2656,22 +2655,22 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IAsyncAction : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IAsyncAction").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getResults", GetResults);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("completed").ToLocalChecked(), CompletedGetter, CompletedSetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2686,13 +2685,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IAsyncAction(::Windows::Foundation::IAsyncAction^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2731,14 +2730,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IAsyncAction^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncAction^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IAsyncAction^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -2763,7 +2762,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -2788,7 +2787,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void GetResults(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2805,7 +2804,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           wrapper->_instance->GetResults();
-          return;   
+          return;
         }
         catch (Platform::Exception ^exception)
         {
@@ -2813,7 +2812,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -2825,7 +2824,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     static void CompletedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IAsyncAction^>(info.This()))
       {
         return;
@@ -2833,7 +2832,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IAsyncAction *wrapper = IAsyncAction::Unwrap<IAsyncAction>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::AsyncActionCompletedHandler^ result = wrapper->_instance->Completed;
         info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Foundation", "AsyncActionCompletedHandler", result));
@@ -2845,11 +2844,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void CompletedSetter(Local<String> property, Local<Value> value, const Nan::PropertyCallbackInfo<void> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::AsyncActionCompletedHandler^>(value))
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Value to set is of unexpected type")));
@@ -2863,9 +2862,9 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IAsyncAction *wrapper = IAsyncAction::Unwrap<IAsyncAction>(info.This());
 
-      try 
+      try
       {
-        
+
         ::Windows::Foundation::AsyncActionCompletedHandler^ winRtValue = dynamic_cast<::Windows::Foundation::AsyncActionCompletedHandler^>(NodeRT::Utils::GetObjectInstance(value));
 
         wrapper->_instance->Completed = winRtValue;
@@ -2875,7 +2874,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         NodeRT::Utils::ThrowWinRtExceptionInJs(exception);
       }
     }
-    
+
 
 
   private:
@@ -2914,24 +2913,24 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IMemoryBufferReference : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IMemoryBufferReference").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                        
+
+
       Nan::SetPrototypeMethod(localRef,"addListener", AddListener);
       Nan::SetPrototypeMethod(localRef,"on", AddListener);
       Nan::SetPrototypeMethod(localRef,"removeListener", RemoveListener);
       Nan::SetPrototypeMethod(localRef, "off", RemoveListener);
-            
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("capacity").ToLocalChecked(), CapacityGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -2946,13 +2945,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IMemoryBufferReference(::Windows::Foundation::IMemoryBufferReference^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -2991,14 +2990,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IMemoryBufferReference^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IMemoryBufferReference^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IMemoryBufferReference^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3023,7 +3022,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3048,14 +3047,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
 
 
 
     static void CapacityGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IMemoryBufferReference^>(info.This()))
       {
         return;
@@ -3063,7 +3062,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IMemoryBufferReference *wrapper = IMemoryBufferReference::Unwrap<IMemoryBufferReference>(info.This());
 
-      try 
+      try
       {
         unsigned int result = wrapper->_instance->Capacity;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -3075,7 +3074,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
     static void AddListener(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -3090,9 +3089,9 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       String::Value eventName(info[0]);
       auto str = *eventName;
-      
+
       Local<Function> callback = info[1].As<Function>();
-      
+
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       if (NodeRT::Utils::CaseInsenstiveEquals(L"closed", str))
       {
@@ -3102,12 +3101,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 		  return;
         }
         IMemoryBufferReference *wrapper = IMemoryBufferReference::Unwrap<IMemoryBufferReference>(info.This());
-      
+
         try
         {
           Persistent<Object>* perstPtr = new Persistent<Object>();
           perstPtr->Reset(NodeRT::Utils::CreateCallbackObjectInDomain(callback));
-          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr, 
+          std::shared_ptr<Persistent<Object>> callbackObjPtr(perstPtr,
             [] (Persistent<Object> *ptr ) {
               NodeUtils::Async::RunOnMain([ptr]() {
                 ptr->Reset();
@@ -3151,7 +3150,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         }
 
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
@@ -3194,7 +3193,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Local<Function> callback = info[1].As<Function>();
       Local<Value> tokenMap = NodeRT::Utils::GetHiddenValue(callback, Nan::New<String>(REGISTRATION_TOKEN_MAP_PROPERTY_NAME).ToLocalChecked());
-                
+
       if (tokenMap.IsEmpty() || Nan::Equals(tokenMap, Undefined()).FromMaybe(false))
       {
         return;
@@ -3208,12 +3207,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       }
 
       OpaqueWrapper *opaqueWrapper = OpaqueWrapper::Unwrap<OpaqueWrapper>(opaqueWrapperObj.As<Object>());
-            
+
       long long tokenValue = (long long) opaqueWrapper->GetObjectInstance();
       ::Windows::Foundation::EventRegistrationToken registrationToken;
       registrationToken.Value = tokenValue;
-        
-      try 
+
+      try
       {
         if (NodeRT::Utils::CaseInsenstiveEquals(L"closed", str))
         {
@@ -3269,20 +3268,20 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IMemoryBuffer : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IMemoryBuffer").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "createReference", CreateReference);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3297,13 +3296,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IMemoryBuffer(::Windows::Foundation::IMemoryBuffer^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3342,14 +3341,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IMemoryBuffer^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IMemoryBuffer^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IMemoryBuffer^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3374,7 +3373,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3399,7 +3398,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void CreateReference(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3426,7 +3425,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3473,21 +3472,21 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class MemoryBuffer : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("MemoryBuffer").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "createReference", CreateReference);
       Nan::SetPrototypeMethod(localRef, "close", Close);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3502,13 +3501,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     MemoryBuffer(::Windows::Foundation::MemoryBuffer^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3547,14 +3546,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::MemoryBuffer^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::MemoryBuffer^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::MemoryBuffer^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3570,7 +3569,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           winRtInstance = ref new ::Windows::Foundation::MemoryBuffer(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -3594,7 +3593,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3619,7 +3618,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void CreateReference(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3646,7 +3645,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3677,7 +3676,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 		  return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
 		return;
@@ -3725,24 +3724,24 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class WwwFormUrlDecoder : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("WwwFormUrlDecoder").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getFirstValueByName", GetFirstValueByName);
       Nan::SetPrototypeMethod(localRef, "first", First);
       Nan::SetPrototypeMethod(localRef, "getAt", GetAt);
       Nan::SetPrototypeMethod(localRef, "indexOf", IndexOf);
       Nan::SetPrototypeMethod(localRef, "getMany", GetMany);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -3757,13 +3756,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     WwwFormUrlDecoder(::Windows::Foundation::WwwFormUrlDecoder^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3802,14 +3801,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::WwwFormUrlDecoder^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::WwwFormUrlDecoder^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::WwwFormUrlDecoder^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -3825,7 +3824,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           winRtInstance = ref new ::Windows::Foundation::WwwFormUrlDecoder(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -3849,7 +3848,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -3874,7 +3873,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void GetFirstValueByName(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -3892,7 +3891,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           Platform::String^ result;
           result = wrapper->_instance->GetFirstValueByName(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -3904,7 +3903,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3927,7 +3926,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         {
           ::Windows::Foundation::Collections::IIterator<::Windows::Foundation::IWwwFormUrlDecoderEntry^>^ result;
           result = wrapper->_instance->First();
-          info.GetReturnValue().Set(NodeRT::Collections::IteratorWrapper<::Windows::Foundation::IWwwFormUrlDecoderEntry^>::CreateIteratorWrapper(result, 
+          info.GetReturnValue().Set(NodeRT::Collections::IteratorWrapper<::Windows::Foundation::IWwwFormUrlDecoderEntry^>::CreateIteratorWrapper(result,
             [](::Windows::Foundation::IWwwFormUrlDecoderEntry^ val) -> Local<Value> {
               return WrapIWwwFormUrlDecoderEntry(val);
             }
@@ -3940,7 +3939,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3963,7 +3962,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           unsigned int arg0 = static_cast<unsigned int>(Nan::To<uint32_t>(info[0]).FromMaybe(0));
-          
+
           ::Windows::Foundation::IWwwFormUrlDecoderEntry^ result;
           result = wrapper->_instance->GetAt(arg0);
           info.GetReturnValue().Set(WrapIWwwFormUrlDecoderEntry(result));
@@ -3975,7 +3974,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -3999,7 +3998,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         {
           ::Windows::Foundation::IWwwFormUrlDecoderEntry^ arg0 = UnwrapIWwwFormUrlDecoderEntry(info[0]);
           unsigned int arg1;
-          
+
           bool result;
           result = wrapper->_instance->IndexOf(arg0, &arg1);
           Local<Object> resObj = Nan::New<Object>();
@@ -4014,7 +4013,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4066,20 +4065,20 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IWwwFormUrlDecoderEntry : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IWwwFormUrlDecoderEntry").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("name").ToLocalChecked(), NameGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("value").ToLocalChecked(), ValueGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4094,13 +4093,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IWwwFormUrlDecoderEntry(::Windows::Foundation::IWwwFormUrlDecoderEntry^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4139,14 +4138,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IWwwFormUrlDecoderEntry^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IWwwFormUrlDecoderEntry^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IWwwFormUrlDecoderEntry^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4171,7 +4170,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4196,14 +4195,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
 
 
 
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IWwwFormUrlDecoderEntry^>(info.This()))
       {
         return;
@@ -4211,7 +4210,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IWwwFormUrlDecoderEntry *wrapper = IWwwFormUrlDecoderEntry::Unwrap<IWwwFormUrlDecoderEntry>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -4223,11 +4222,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void ValueGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IWwwFormUrlDecoderEntry^>(info.This()))
       {
         return;
@@ -4235,7 +4234,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IWwwFormUrlDecoderEntry *wrapper = IWwwFormUrlDecoderEntry::Unwrap<IWwwFormUrlDecoderEntry>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Value;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -4247,7 +4246,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
   private:
@@ -4286,20 +4285,20 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class WwwFormUrlDecoderEntry : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("WwwFormUrlDecoderEntry").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-                              
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("name").ToLocalChecked(), NameGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("value").ToLocalChecked(), ValueGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4314,13 +4313,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     WwwFormUrlDecoderEntry(::Windows::Foundation::WwwFormUrlDecoderEntry^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4359,14 +4358,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::WwwFormUrlDecoderEntry^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::WwwFormUrlDecoderEntry^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::WwwFormUrlDecoderEntry^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4391,7 +4390,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4416,14 +4415,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
 
 
 
     static void NameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::WwwFormUrlDecoderEntry^>(info.This()))
       {
         return;
@@ -4431,7 +4430,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       WwwFormUrlDecoderEntry *wrapper = WwwFormUrlDecoderEntry::Unwrap<WwwFormUrlDecoderEntry>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Name;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -4443,11 +4442,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void ValueGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::WwwFormUrlDecoderEntry^>(info.This()))
       {
         return;
@@ -4455,7 +4454,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       WwwFormUrlDecoderEntry *wrapper = WwwFormUrlDecoderEntry::Unwrap<WwwFormUrlDecoderEntry>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Value;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -4467,7 +4466,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
   private:
@@ -4506,20 +4505,20 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IGetActivationFactory : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IGetActivationFactory").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getActivationFactory", GetActivationFactory);
-      
-                        
+
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4534,13 +4533,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IGetActivationFactory(::Windows::Foundation::IGetActivationFactory^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4579,14 +4578,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IGetActivationFactory^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IGetActivationFactory^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IGetActivationFactory^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4611,7 +4610,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4636,7 +4635,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void GetActivationFactory(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4654,7 +4653,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           ::Platform::Object^ result;
           result = wrapper->_instance->GetActivationFactory(arg0);
           info.GetReturnValue().Set(CreateOpaqueWrapper(result));
@@ -4666,7 +4665,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4713,17 +4712,17 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class IPropertyValue : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("IPropertyValue").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "getUInt8", GetUInt8);
       Nan::SetPrototypeMethod(localRef, "getInt16", GetInt16);
       Nan::SetPrototypeMethod(localRef, "getUInt16", GetUInt16);
@@ -4761,11 +4760,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       Nan::SetPrototypeMethod(localRef, "getPointArray", GetPointArray);
       Nan::SetPrototypeMethod(localRef, "getSizeArray", GetSizeArray);
       Nan::SetPrototypeMethod(localRef, "getRectArray", GetRectArray);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("isNumericScalar").ToLocalChecked(), IsNumericScalarGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("type").ToLocalChecked(), TypeGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -4780,13 +4779,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     IPropertyValue(::Windows::Foundation::IPropertyValue^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4825,14 +4824,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::IPropertyValue^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IPropertyValue^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::IPropertyValue^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -4857,7 +4856,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -4882,7 +4881,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void GetUInt8(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -4909,7 +4908,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4941,7 +4940,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -4973,7 +4972,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5005,7 +5004,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5037,7 +5036,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5069,7 +5068,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5101,7 +5100,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5133,7 +5132,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5165,7 +5164,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5197,7 +5196,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5229,7 +5228,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5261,7 +5260,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5293,7 +5292,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5325,7 +5324,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5357,7 +5356,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5389,7 +5388,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5421,7 +5420,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5453,7 +5452,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5475,10 +5474,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<unsigned char>^ arg0;
-          
+
           wrapper->_instance->GetUInt8Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned char>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned char>::CreateArrayWrapper(arg0,
             [](unsigned char val) -> Local<Value> {
               return Nan::New<Integer>(val);
             },
@@ -5498,7 +5497,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5520,10 +5519,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<short>^ arg0;
-          
+
           wrapper->_instance->GetInt16Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<short>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<short>::CreateArrayWrapper(arg0,
             [](short val) -> Local<Value> {
               return Nan::New<Integer>(val);
             },
@@ -5543,7 +5542,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5565,10 +5564,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<unsigned short>^ arg0;
-          
+
           wrapper->_instance->GetUInt16Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned short>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned short>::CreateArrayWrapper(arg0,
             [](unsigned short val) -> Local<Value> {
               return Nan::New<Integer>(val);
             },
@@ -5588,7 +5587,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5610,10 +5609,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<int>^ arg0;
-          
+
           wrapper->_instance->GetInt32Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<int>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<int>::CreateArrayWrapper(arg0,
             [](int val) -> Local<Value> {
               return Nan::New<Integer>(val);
             },
@@ -5633,7 +5632,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5655,10 +5654,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<unsigned int>^ arg0;
-          
+
           wrapper->_instance->GetUInt32Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned int>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned int>::CreateArrayWrapper(arg0,
             [](unsigned int val) -> Local<Value> {
               return Nan::New<Integer>(val);
             },
@@ -5678,7 +5677,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5700,10 +5699,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<__int64>^ arg0;
-          
+
           wrapper->_instance->GetInt64Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<__int64>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<__int64>::CreateArrayWrapper(arg0,
             [](__int64 val) -> Local<Value> {
               return Nan::New<Number>(static_cast<double>(val));
             },
@@ -5723,7 +5722,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5745,10 +5744,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<unsigned __int64>^ arg0;
-          
+
           wrapper->_instance->GetUInt64Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned __int64>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<unsigned __int64>::CreateArrayWrapper(arg0,
             [](unsigned __int64 val) -> Local<Value> {
               return Nan::New<Number>(static_cast<double>(val));
             },
@@ -5768,7 +5767,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5790,10 +5789,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<float>^ arg0;
-          
+
           wrapper->_instance->GetSingleArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<float>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<float>::CreateArrayWrapper(arg0,
             [](float val) -> Local<Value> {
               return Nan::New<Number>(static_cast<double>(val));
             },
@@ -5813,7 +5812,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5835,10 +5834,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<double>^ arg0;
-          
+
           wrapper->_instance->GetDoubleArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<double>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<double>::CreateArrayWrapper(arg0,
             [](double val) -> Local<Value> {
               return Nan::New<Number>(static_cast<double>(val));
             },
@@ -5858,7 +5857,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5880,10 +5879,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<wchar_t>^ arg0;
-          
+
           wrapper->_instance->GetChar16Array(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<wchar_t>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<wchar_t>::CreateArrayWrapper(arg0,
             [](wchar_t val) -> Local<Value> {
               return NodeRT::Utils::JsStringFromChar(val);
             },
@@ -5903,7 +5902,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5925,10 +5924,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<bool>^ arg0;
-          
+
           wrapper->_instance->GetBooleanArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<bool>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<bool>::CreateArrayWrapper(arg0,
             [](bool val) -> Local<Value> {
               return Nan::New<Boolean>(val);
             },
@@ -5948,7 +5947,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -5970,10 +5969,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Platform::String^>^ arg0;
-          
+
           wrapper->_instance->GetStringArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::String^>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::String^>::CreateArrayWrapper(arg0,
             [](::Platform::String^ val) -> Local<Value> {
               return NodeRT::Utils::NewString(val->Data());
             },
@@ -5993,7 +5992,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6015,10 +6014,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Platform::Object^>^ arg0;
-          
+
           wrapper->_instance->GetInspectableArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::Object^>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::Object^>::CreateArrayWrapper(arg0,
             [](::Platform::Object^ val) -> Local<Value> {
               return CreateOpaqueWrapper(val);
             },
@@ -6038,7 +6037,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6060,10 +6059,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Platform::Guid>^ arg0;
-          
+
           wrapper->_instance->GetGuidArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::Guid>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Platform::Guid>::CreateArrayWrapper(arg0,
             [](::Platform::Guid val) -> Local<Value> {
               return NodeRT::Utils::GuidToJs(val);
             },
@@ -6083,7 +6082,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6105,10 +6104,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Windows::Foundation::DateTime>^ arg0;
-          
+
           wrapper->_instance->GetDateTimeArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::DateTime>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::DateTime>::CreateArrayWrapper(arg0,
             [](::Windows::Foundation::DateTime val) -> Local<Value> {
               return NodeRT::Utils::DateTimeToJS(val);
             },
@@ -6128,7 +6127,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6150,10 +6149,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Windows::Foundation::TimeSpan>^ arg0;
-          
+
           wrapper->_instance->GetTimeSpanArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::TimeSpan>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::TimeSpan>::CreateArrayWrapper(arg0,
             [](::Windows::Foundation::TimeSpan val) -> Local<Value> {
               return Nan::New<Number>(val.Duration/10000.0);
             },
@@ -6173,7 +6172,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6195,10 +6194,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Windows::Foundation::Point>^ arg0;
-          
+
           wrapper->_instance->GetPointArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Point>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Point>::CreateArrayWrapper(arg0,
             [](::Windows::Foundation::Point val) -> Local<Value> {
               return NodeRT::Utils::PointToJs(val);
             },
@@ -6218,7 +6217,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6240,10 +6239,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Windows::Foundation::Size>^ arg0;
-          
+
           wrapper->_instance->GetSizeArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Size>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Size>::CreateArrayWrapper(arg0,
             [](::Windows::Foundation::Size val) -> Local<Value> {
               return NodeRT::Utils::SizeToJs(val);
             },
@@ -6263,7 +6262,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6285,10 +6284,10 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Platform::Array<::Windows::Foundation::Rect>^ arg0;
-          
+
           wrapper->_instance->GetRectArray(&arg0);
           Local<Object> resObj = Nan::New<Object>();
-          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Rect>::CreateArrayWrapper(arg0, 
+          Nan::Set(resObj, Nan::New<String>("value").ToLocalChecked(), NodeRT::Collections::ArrayWrapper<::Windows::Foundation::Rect>::CreateArrayWrapper(arg0,
             [](::Windows::Foundation::Rect val) -> Local<Value> {
               return NodeRT::Utils::RectToJs(val);
             },
@@ -6308,7 +6307,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6320,7 +6319,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     static void IsNumericScalarGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IPropertyValue^>(info.This()))
       {
         return;
@@ -6328,7 +6327,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IPropertyValue *wrapper = IPropertyValue::Unwrap<IPropertyValue>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->IsNumericScalar;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -6340,11 +6339,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void TypeGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::IPropertyValue^>(info.This()))
       {
         return;
@@ -6352,7 +6351,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       IPropertyValue *wrapper = IPropertyValue::Unwrap<IPropertyValue>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::PropertyType result = wrapper->_instance->Type;
         info.GetReturnValue().Set(Nan::New<Integer>(static_cast<int>(result)));
@@ -6364,7 +6363,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
   private:
@@ -6403,22 +6402,22 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
   class Uri : public WrapperBase
   {
-  public:    
+  public:
     static void Init(const Local<Object> exports)
     {
       HandleScope scope;
-      
+
       Local<FunctionTemplate> localRef = Nan::New<FunctionTemplate>(New);
       s_constructorTemplate.Reset(localRef);
       localRef->SetClassName(Nan::New<String>("Uri").ToLocalChecked());
       localRef->InstanceTemplate()->SetInternalFieldCount(1);
-      
-            
+
+
       Nan::SetPrototypeMethod(localRef, "equals", Equals);
       Nan::SetPrototypeMethod(localRef, "combineUri", CombineUri);
       Nan::SetPrototypeMethod(localRef, "toString", ToString);
-      
-                        
+
+
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("absoluteUri").ToLocalChecked(), AbsoluteUriGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("displayUri").ToLocalChecked(), DisplayUriGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("domain").ToLocalChecked(), DomainGetter);
@@ -6436,7 +6435,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("userName").ToLocalChecked(), UserNameGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("absoluteCanonicalUri").ToLocalChecked(), AbsoluteCanonicalUriGetter);
       Nan::SetAccessor(localRef->PrototypeTemplate(), Nan::New<String>("displayIri").ToLocalChecked(), DisplayIriGetter);
-      
+
       Local<Object> constructor = Nan::To<Object>(Nan::GetFunction(localRef).ToLocalChecked()).ToLocalChecked();
 	  Nan::SetMethod(constructor, "castFrom", CastFrom);
 
@@ -6453,13 +6452,13 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
   private:
-    
+
     Uri(::Windows::Foundation::Uri^ instance)
     {
       _instance = instance;
     }
-    
-    
+
+
     static void New(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6498,14 +6497,14 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      
+
       ::Windows::Foundation::Uri^ winRtInstance;
 
 
       if (info.Length() == 1 && OpaqueWrapper::IsOpaqueWrapper(info[0]) &&
         NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info[0]))
       {
-        try 
+        try
         {
           winRtInstance = (::Windows::Foundation::Uri^) NodeRT::Utils::GetObjectInstance(info[0]);
         }
@@ -6521,7 +6520,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           winRtInstance = ref new ::Windows::Foundation::Uri(arg0);
         }
         catch (Platform::Exception ^exception)
@@ -6538,7 +6537,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
           Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[1])));
-          
+
           winRtInstance = ref new ::Windows::Foundation::Uri(arg0,arg1);
         }
         catch (Platform::Exception ^exception)
@@ -6562,7 +6561,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-	
+
     static void CastFrom(Nan::NAN_METHOD_ARGS_TYPE info)
     {
 		HandleScope scope;
@@ -6587,7 +6586,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     }
 
 
-  
+
     static void Equals(Nan::NAN_METHOD_ARGS_TYPE info)
     {
       HandleScope scope;
@@ -6605,7 +6604,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           ::Windows::Foundation::Uri^ arg0 = dynamic_cast<::Windows::Foundation::Uri^>(NodeRT::Utils::GetObjectInstance(info[0]));
-          
+
           bool result;
           result = wrapper->_instance->Equals(arg0);
           info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -6617,7 +6616,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6640,7 +6639,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           ::Windows::Foundation::Uri^ result;
           result = wrapper->_instance->CombineUri(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::CreateExternalWinRTObject("Windows.Foundation", "Uri", result));
@@ -6652,7 +6651,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6684,7 +6683,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6702,7 +6701,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           Platform::String^ result;
           result = ::Windows::Foundation::Uri::UnescapeComponent(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6714,7 +6713,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6730,7 +6729,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         try
         {
           Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          
+
           Platform::String^ result;
           result = ::Windows::Foundation::Uri::EscapeComponent(arg0);
           info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6742,7 +6741,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
           return;
         }
       }
-      else 
+      else
       {
         Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"Bad arguments: no suitable overload found")));
         return;
@@ -6752,7 +6751,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     static void AbsoluteUriGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6760,7 +6759,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->AbsoluteUri;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6772,11 +6771,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void DisplayUriGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6784,7 +6783,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DisplayUri;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6796,11 +6795,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void DomainGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6808,7 +6807,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Domain;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6820,11 +6819,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void ExtensionGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6832,7 +6831,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Extension;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6844,11 +6843,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void FragmentGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6856,7 +6855,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Fragment;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6868,11 +6867,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void HostGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6880,7 +6879,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Host;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6892,11 +6891,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void PasswordGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6904,7 +6903,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Password;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6916,11 +6915,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void PathGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6928,7 +6927,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Path;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6940,11 +6939,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void PortGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6952,7 +6951,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         int result = wrapper->_instance->Port;
         info.GetReturnValue().Set(Nan::New<Integer>(result));
@@ -6964,11 +6963,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void QueryGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -6976,7 +6975,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->Query;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -6988,11 +6987,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void QueryParsedGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7000,7 +6999,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         ::Windows::Foundation::WwwFormUrlDecoder^ result = wrapper->_instance->QueryParsed;
         info.GetReturnValue().Set(WrapWwwFormUrlDecoder(result));
@@ -7012,11 +7011,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void RawUriGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7024,7 +7023,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->RawUri;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -7036,11 +7035,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void SchemeNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7048,7 +7047,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->SchemeName;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -7060,11 +7059,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void SuspiciousGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7072,7 +7071,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         bool result = wrapper->_instance->Suspicious;
         info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -7084,11 +7083,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void UserNameGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7096,7 +7095,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->UserName;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -7108,11 +7107,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void AbsoluteCanonicalUriGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7120,7 +7119,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->AbsoluteCanonicalUri;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -7132,11 +7131,11 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
     static void DisplayIriGetter(Local<String> property, const Nan::PropertyCallbackInfo<v8::Value> &info)
     {
       HandleScope scope;
-      
+
       if (!NodeRT::Utils::IsWinRtWrapperOf<::Windows::Foundation::Uri^>(info.This()))
       {
         return;
@@ -7144,7 +7143,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 
       Uri *wrapper = Uri::Unwrap<Uri>(info.This());
 
-      try 
+      try
       {
         Platform::String^ result = wrapper->_instance->DisplayIri;
         info.GetReturnValue().Set(NodeRT::Utils::NewString(result->Data()));
@@ -7156,7 +7155,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
     }
-    
+
 
 
   private:
@@ -7193,7 +7192,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
     Uri::Init(exports);
   }
 
-} } } 
+} } }
 
 NAN_MODULE_INIT(init)
 {
@@ -7204,7 +7203,7 @@ NAN_MODULE_INIT(init)
     Nan::ThrowError(Nan::Error(NodeRT::Utils::NewString(L"error in CoInitializeEx()")));
     return;
   }*/
-  
+
   NodeRT::Windows::Foundation::InitPropertyTypeEnum(target);
   NodeRT::Windows::Foundation::InitAsyncStatusEnum(target);
   NodeRT::Windows::Foundation::InitPropertyValue(target);

--- a/uwp/windows.foundation/node-async.h
+++ b/uwp/windows.foundation/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.foundation/node-async.h
+++ b/uwp/windows.foundation/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {

--- a/uwp/windows.storage.streams/CollectionsWrap.h
+++ b/uwp/windows.storage.streams/CollectionsWrap.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;

--- a/uwp/windows.storage.streams/NodeRtUtils.cpp
+++ b/uwp/windows.storage.streams/NodeRtUtils.cpp
@@ -196,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))

--- a/uwp/windows.storage.streams/NodeRtUtils.cpp
+++ b/uwp/windows.storage.streams/NodeRtUtils.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -77,12 +76,12 @@ namespace NodeRT { namespace Utils {
   Local<v8::Object> CreateCallbackObjectInDomain(Local<v8::Function> callback)
   {
     EscapableHandleScope scope;
-    
+
     // get the current domain:
     MaybeLocal<v8::Object> callbackObject = Nan::New<Object>();
-    
+
     Nan::Set(callbackObject.ToLocalChecked(), Nan::New<String>("callback").ToLocalChecked(), callback);
-    
+
     MaybeLocal<Value> processVal = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("process").ToLocalChecked());
     v8::Local<Object> process = Nan::To<Object>(processVal.ToLocalChecked()).ToLocalChecked();
     if (process.IsEmpty() || Nan::Equals(process,Undefined()).FromMaybe(true))
@@ -105,14 +104,14 @@ namespace NodeRT { namespace Utils {
   //    "callback" : [callback function]
   //    "domain" : [the domain in which the async function/event was called/registered] (this is optional)
   // }
-  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[]) 
+  Local<Value> CallCallbackInDomain(Local<v8::Object> callbackObject, int argc, Local<Value> argv[])
   {
     return Nan::MakeCallback(callbackObject, Nan::New<String>("callback").ToLocalChecked(), argc, argv);
   }
 
   ::Platform::Object^ GetObjectInstance(Local<Value> value)
   {
-    // nulls are allowed when a WinRT wrapped object is expected 
+    // nulls are allowed when a WinRT wrapped object is expected
     if (value->IsNull()) {
       return nullptr;
     }
@@ -184,7 +183,7 @@ namespace NodeRT { namespace Utils {
   {
     HandleScope scope;
     Local<Object> global = Nan::GetCurrentContext()->Global();
-    
+
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
     {
 		  Nan::ForceSet(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked(), Nan::New<Object>(), (v8::PropertyAttribute) (v8::PropertyAttribute::DontEnum & v8::PropertyAttribute::DontDelete));
@@ -298,7 +297,7 @@ namespace NodeRT { namespace Utils {
       time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
     }
 
-    return time; 
+    return time;
   }
 
   Local<Date> DateTimeToJS(::Windows::Foundation::DateTime value)
@@ -350,7 +349,7 @@ namespace NodeRT { namespace Utils {
   {
     OLECHAR* bstrGuid;
     StringFromCLSID(guid, &bstrGuid);
-    
+
     Local<String> strVal = NewString(bstrGuid);
     CoTaskMemFree(bstrGuid);
     return strVal;
@@ -381,7 +380,7 @@ namespace NodeRT { namespace Utils {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (!Nan::Has(obj, Nan::New<String>("G").ToLocalChecked()).FromMaybe(false))
     {
-      
+
       retVal.G = static_cast<unsigned char>(Nan::To<uint32_t>(Nan::Get(obj, Nan::New<String>("G").ToLocalChecked()).ToLocalChecked()).FromMaybe(0));
     }
 
@@ -462,10 +461,10 @@ namespace NodeRT { namespace Utils {
     }
 
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    
+
     if (Nan::Has(obj, Nan::New<String>("x").ToLocalChecked()).FromMaybe(false))
     {
-		
+
       rect.X = static_cast<float>(Nan::To<double>(Nan::Get(obj, Nan::New<String>("x").ToLocalChecked()).ToLocalChecked()).FromMaybe(0.0));
     }
 
@@ -532,7 +531,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Point PointFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Point point(0,0);  
+    ::Windows::Foundation::Point point(0,0);
 
     if (!value->IsObject())
     {
@@ -590,7 +589,7 @@ namespace NodeRT { namespace Utils {
 
   ::Windows::Foundation::Size SizeFromJs(Local<Value> value)
   {
-    ::Windows::Foundation::Size size(0,0);  
+    ::Windows::Foundation::Size size(0,0);
 
     if (!value->IsObject())
     {
@@ -671,4 +670,4 @@ namespace NodeRT { namespace Utils {
     return res;
   }
 
-} } 
+} }

--- a/uwp/windows.storage.streams/OpaqueWrapper.h
+++ b/uwp/windows.storage.streams/OpaqueWrapper.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -31,14 +31,14 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
-	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;

--- a/uwp/windows.storage.streams/_nodert_generated.cpp
+++ b/uwp/windows.storage.streams/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;

--- a/uwp/windows.storage.streams/node-async.h
+++ b/uwp/windows.storage.streams/node-async.h
@@ -46,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
 
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
 
   class Async
   {
@@ -68,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -116,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -135,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -157,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback,
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -178,8 +178,8 @@ namespace NodeUtils
       std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork,
       std::function<void (Baton<TInput, TResult>*)> afterWork,
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -201,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -213,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -238,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -278,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -296,7 +296,7 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
@@ -350,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error)
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
 

--- a/uwp/windows.storage.streams/node-async.h
+++ b/uwp/windows.storage.streams/node-async.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
-// All rights reserved. 
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+// Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT. 
+// THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
 //
 // See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
 
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -46,14 +45,14 @@ namespace NodeUtils
   using Nan::Null;
   using Nan::Persistent;
   using Nan::Undefined;
-  
+
   typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
-  
+
   class Async
   {
   public:
-    template<typename TInput, typename TResult> 
-    struct Baton 
+    template<typename TInput, typename TResult>
+    struct Baton
     {
       int error_code;
       std::wstring error_message;
@@ -64,7 +63,7 @@ namespace NodeUtils
       std::shared_ptr<Persistent<Value>> callback_args;
       unsigned callback_args_size;
 
-      Baton() 
+      Baton()
       {
         callback_args_size = 0;
       }
@@ -85,7 +84,7 @@ namespace NodeUtils
           callback_info.get()[i].Reset(argv[i]);
         }
       }
-      
+
       virtual ~Baton()
       {
         for (int i = 0; i < callback_args_size; i++)
@@ -117,7 +116,7 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
@@ -136,7 +135,7 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
@@ -158,7 +157,7 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
+        Handle<Function> callback,
         Handle<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
@@ -174,17 +173,17 @@ namespace NodeUtils
     };
 
   public:
-    template<typename TInput, typename TResult> 
+    template<typename TInput, typename TResult>
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
-      std::function<void (Baton<TInput, TResult>*)> doWork, 
-      std::function<void (Baton<TInput, TResult>*)> afterWork, 
+      std::shared_ptr<TInput> input,
+      std::function<void (Baton<TInput, TResult>*)> doWork,
+      std::function<void (Baton<TInput, TResult>*)> afterWork,
       Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
-      
+
       Baton<TInput, TResult>* baton = new Baton<TInput, TResult>();
       baton->request.data = baton;
       baton->callbackData.Reset(callbackData);
@@ -202,7 +201,7 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
@@ -214,7 +213,7 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
+      Handle<Function> callback,
       Handle<Value> receiver = Handle<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
@@ -305,14 +304,14 @@ namespace NodeUtils
       if (!callback.IsEmpty() && !callback->Equals(Undefined()))
       {
         callbackData = New<Object>();
-        
+
         if (!receiver.IsEmpty())
         {
           Nan::SetPrototype(callbackData, receiver);
         }
-        
+
         Nan::Set(callbackData, New<String>("callback").ToLocalChecked(), callback);
-      
+
         // get the current domain:
         Local<Value> currentDomain = Undefined();
 
@@ -328,8 +327,8 @@ namespace NodeUtils
       return scope.Escape(callbackData);
     };
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncWork(uv_work_t* req) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncWork(uv_work_t* req)
     {
       // No HandleScope!
 
@@ -342,14 +341,14 @@ namespace NodeUtils
     }
 
 
-    template<typename TInput, typename TResult> 
-    static void __cdecl AsyncAfter(uv_work_t* req, int status) 
+    template<typename TInput, typename TResult>
+    static void __cdecl AsyncAfter(uv_work_t* req, int status)
     {
       HandleScope scope;;
       Baton<TInput, TResult>* baton = static_cast<Baton<TInput, TResult>*>(req->data);
 
       // typical AfterWorkFunc implementation
-      //if (baton->error) 
+      //if (baton->error)
       //{
       //  Handle<Value> err = Exception::Error(...);
       //  Handle<Value> argv[] = { err };
@@ -359,10 +358,10 @@ namespace NodeUtils
       //{
       //  Handle<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
-      //} 
+      //}
 
       baton->afterWork(baton);
-      
+
       if (!baton->callbackData.IsEmpty())
       {
         // call the callback, using domains and all
@@ -375,13 +374,13 @@ namespace NodeUtils
 
         MakeCallback(New(baton->callbackData), New<String>("callback").ToLocalChecked(), argc, handlesArr.get());
       }
-      
+
       baton->callbackData.Reset();
       delete baton;
     }
-    
+
     // called after the async handle is closed in order to free it's memory
-    static void __cdecl AyncCloseCb(uv_handle_t* handle) 
+    static void __cdecl AyncCloseCb(uv_handle_t* handle)
     {
       if (handle != nullptr)
       {


### PR DESCRIPTION
This pr resolves electron native build failure in electron 5.0.
As V8 is updated in Electron 5.0, replacing deprecated v8::Handle class is needed.
https://electronjs.org/blog/nodejs-native-addons-and-electron-5

I only replaced v8::Handle to v8::Local, and confirmed that it work properly with following combinations.
- Electron 5.0.1 / Nodejs 12.2
- Electron 4.2.0 / Nodejs 12.2
- Electron 3.1.9 / Nodejs 12.2
