### PR TITLE
Add support for discovering ONLY one service when desired. Fix broken…

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -192,13 +192,13 @@ NobleBindings.prototype.discoverServices = function (deviceUuid, filterServiceUu
 		throw new Error('Device is not connected. UUID: ' + deviceUuid);
 	}
 
-	rt.promisify(device.getGattServicesAsync, device)(
-		BluetoothCacheMode.uncached).then(result => {
+	if (filterServiceUuids && filterServiceUuids.length === 1) {
+		rt.promisify(device.getGattServicesForUuidAsync, device)(
+			addDashesToUuid(filterServiceUuids[0])).then(result => {
 			checkCommunicationResult(deviceUuid, result);
 
 			let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
-			let serviceUuids = services.map(s => uuidToString(s.uuid))
-				.filter(filterUuids(filterServiceUuids));
+			let serviceUuids = services.map(s => uuidToString(s.uuid));
 
 			debug(deviceUuid + ' services: %o', serviceUuids);
 			this.emit('servicesDiscover', deviceUuid, serviceUuids);
@@ -206,6 +206,23 @@ NobleBindings.prototype.discoverServices = function (deviceUuid, filterServiceUu
 			debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
 			this.emit('servicesDiscover', deviceUuid, ex);
 		});
+		return;
+	}
+
+	rt.promisify(device.getGattServicesAsync, device)(
+		BluetoothCacheMode.uncached).then(result => {
+		checkCommunicationResult(deviceUuid, result);
+
+		let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
+		let serviceUuids = services.map(s => uuidToString(s.uuid))
+		.filter(filterUuids(filterServiceUuids));
+
+		debug(deviceUuid + ' services: %o', serviceUuids);
+		this.emit('servicesDiscover', deviceUuid, serviceUuids);
+	}).catch(ex => {
+		debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
+		this.emit('servicesDiscover', deviceUuid, ex);
+	});
 };
 
 NobleBindings.prototype.discoverIncludedServices =
@@ -825,6 +842,10 @@ function stringToUuid(uuid) {
 	} else {
 		return uuid;
 	}
+}
+
+function addDashesToUuid(i) {
+	return i.substr(0,8)+"-"+i.substr(8,4)+"-"+i.substr(12,4)+"-"+i.substr(16,4)+"-"+i.substr(20);
 }
 
 function uuidToString(uuid) {


### PR DESCRIPTION
… passing of Uuids to winrt C code.


This pull request does 2 things:

1. Provides an example of how passing uuids to the winrt code is currently broken (albeit currently unused and not causing issues), and provides an addDashesToUuid utility function that corrects this. 

2. Modifies the discoverServices function in bindings.js to use the more efficient getGattServicesForUuid when the user is only requesting ONE service. 