### PR TITLE
Fix for stuck connectable flag.

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -533,6 +533,7 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 	}
 
 	let connectable;
+	debug('	advertisement type: %s', e.advertisementType);
 	switch (e.advertisementType) {
 		case BluetoothLEAdvertisementType.connectableUndirected:
 		case BluetoothLEAdvertisementType.connectableDirected:
@@ -557,7 +558,7 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 		debug('	data section: %s',
 			(getEnumName(BluetoothLEAdvertisementDataTypes, dataSection.dataType) ||
 				dataSection.dataType));
-		// https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile 
+		// https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile
 		switch (dataSection.dataType) {
 			case BluetoothLEAdvertisementDataTypes.completeService16BitUuids:
 				var id = Buffer.allocUnsafe(2);
@@ -608,6 +609,9 @@ NobleBindings.prototype._onAdvertisementWatcherReceived = function (sender, e) {
 		};
 		this._deviceMap[deviceUuid] = deviceRecord;
 	}
+
+	// update connectable status!
+	deviceRecord.connectable = connectable;
 
 	if (e.advertisement.localName) {
 		deviceRecord.name = e.advertisement.localName;

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -192,13 +192,13 @@ NobleBindings.prototype.discoverServices = function (deviceUuid, filterServiceUu
 		throw new Error('Device is not connected. UUID: ' + deviceUuid);
 	}
 
-	rt.promisify(device.getGattServicesAsync, device)(
-		BluetoothCacheMode.uncached).then(result => {
+	if (filterServiceUuids && filterServiceUuids.length === 1) {
+		rt.promisify(device.getGattServicesForUuidAsync, device)(
+			addDashesToUuid(filterServiceUuids[0])).then(result => {
 			checkCommunicationResult(deviceUuid, result);
 
 			let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
-			let serviceUuids = services.map(s => uuidToString(s.uuid))
-				.filter(filterUuids(filterServiceUuids));
+			let serviceUuids = services.map(s => uuidToString(s.uuid));
 
 			debug(deviceUuid + ' services: %o', serviceUuids);
 			this.emit('servicesDiscover', deviceUuid, serviceUuids);
@@ -206,6 +206,23 @@ NobleBindings.prototype.discoverServices = function (deviceUuid, filterServiceUu
 			debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
 			this.emit('servicesDiscover', deviceUuid, ex);
 		});
+		return;
+	}
+
+	rt.promisify(device.getGattServicesAsync, device)(
+		BluetoothCacheMode.uncached).then(result => {
+		checkCommunicationResult(deviceUuid, result);
+
+		let services = rt.trackDisposables(deviceUuid, rt.toArray(result.services));
+		let serviceUuids = services.map(s => uuidToString(s.uuid))
+		.filter(filterUuids(filterServiceUuids));
+
+		debug(deviceUuid + ' services: %o', serviceUuids);
+		this.emit('servicesDiscover', deviceUuid, serviceUuids);
+	}).catch(ex => {
+		debug('failed to get GATT services for device %s: %s', deviceUuid, ex.stack);
+		this.emit('servicesDiscover', deviceUuid, ex);
+	});
 };
 
 NobleBindings.prototype.discoverIncludedServices =
@@ -825,6 +842,10 @@ function stringToUuid(uuid) {
 	} else {
 		return uuid;
 	}
+}
+
+function addDashesToUuid(i) {
+	return i.substr(0,8)+"-"+i.substr(8,4)+"-"+i.substr(12,4)+"-"+i.substr(16,4)+"-"+i.substr(20);
 }
 
 function uuidToString(uuid) {


### PR DESCRIPTION
The connectable flag is calculated from the first advert per device, and then cached. It never gets updated by subsequent adverts. This commit fixes that. 